### PR TITLE
Fixes service location for deb, fixes old links to docker image

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -286,7 +286,7 @@ nfpms:
       
       # systemd service
       - src: init/systemd/unpoller.service
-        dst: /lib/systemd/service/unpoller.service
+        dst: /etc/systemd/service/unpoller.service
         type: config
       
       # freebsd rc service

--- a/examples/k8s_unifi_poller.yaml
+++ b/examples/k8s_unifi_poller.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: unifi-poller
-        image: golift/unifi-poller:latest
+        image: ghcr.io/unpoller/unpoller:latest
         ports:
         - containerPort: 9130
           name: tcp

--- a/init/synology-docker-compose/docker-compose.yml
+++ b/init/synology-docker-compose/docker-compose.yml
@@ -35,7 +35,7 @@ services:
 
   unifi-poller:
     restart: always
-    image: golift/unifi-poller:latest
+    image: ghcr.io/unpoller/unpoller:${POLLER_TAG}
     environment:
       - UP_INFLUXDB_USER=${INFLUXDB_ADMIN_USER}
       - UP_INFLUXDB_PASS=${INFLUXDB_ADMIN_PASSWORD}


### PR DESCRIPTION
- also fix location of service file for deb #434 

```shell
root@a6e7deab430b:/# dpkg -i /tmp/unpoller/dist/unpoller_0.0.0_Tux_arm64.deb
root@a6e7deab430b:/# ls /etc/systemd/service/
unpoller.service
```

- fix compose files