### PR TITLE
Default Config missing for docker containers

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -266,6 +266,12 @@ nfpms:
       - src: examples/up.yaml.example
         dst: /etc/unpoller/up.yaml.example
         type: config
+      # copy example by default to real locations, people can override, cnfg uses this.
+      - src: examples/up.conf.example
+        dst: /etc/unpoller/up.conf
+        type: config|noreplace
+      
+      # common useful info
       - src: "README.html"
         dst: /etc/unpoller/readme.html
         type: config
@@ -315,7 +321,7 @@ nfpms:
         dst: /usr/local/lib/unpoller/web/static/index.html
         type: config
       - src: init/webserver/static/css/*
-        dst: /usr/local/lib/unpoller/web/static//css
+        dst: /usr/local/lib/unpoller/web/static/css
         type: config
       - src: init/webserver/static/images/*
         dst: /usr/local/lib/unpoller/web/static/images

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,15 @@
+FROM busybox:latest as builder
+# we have to do this hop because distroless is bare without common shell commands
+
+RUN mkdir -p /etc/unpoller
+# copy over example config for cnfg environment-based default config
+COPY examples/up.conf.example /etc/unpoller/up.conf
+COPY unpoller_manual.html /etc/unpoller/manual.html
+COPY README.html /etc/unpoller/readme.html
+
 FROM gcr.io/distroless/static-debian11
 
 COPY unpoller /usr/bin/unpoller
+COPY --from=builder /etc/unpoller /etc/unpoller
 
 ENTRYPOINT [ "/usr/bin/unpoller" ]

--- a/examples/up.conf.example
+++ b/examples/up.conf.example
@@ -56,6 +56,7 @@
 # Pick which logs you want per-controller in the [unifi.controller] section.
 # This is a new feature. Feedback welcome!
 [loki]
+  disable = true
   url = ""
   # The rest of this is advanced & optional. See wiki.
   user       = ""

--- a/init/docker/docker-compose.env.example
+++ b/init/docker/docker-compose.env.example
@@ -1,8 +1,11 @@
 #influxdb
 INFLUXDB_HTTP_AUTH_ENABLED=true
-INFLUXDB_ADMIN_USER=unifi-poller
+INFLUXDB_ADMIN_USER=unpoller
 INFLUXDB_ADMIN_PASSWORD=CHANGEME
-INFLUXDB_DB=unifi
+INFLUXDB_DB=unpoller
+INFLUXDB_ORG=unpoller
+INFLUXDB_BUCKET=unpoller
+INFLUXDB_ADMIN_TOKEN=unpollersecret
 
 #grafana
 GRAFANA_USERNAME=admin
@@ -12,6 +15,6 @@ GRAFANA_PASSWORD=grafanaadmin
 POLLER_TAG=latest
 POLLER_DEBUG=false
 POLLER_SAVE_DPI=false
-UNIFI_USER=unifipoller
+UNIFI_USER=unpoller
 UNIFI_PASS=set_this_on_your_controller
 UNIFI_URL=https://127.0.0.1:8443

--- a/init/docker/docker-compose.yml
+++ b/init/docker/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   influxdb:
     restart: always
-    image: influxdb:1.8
+    image: influxdb:2.5
     ports:
       - '8086:8086'
     volumes:
@@ -11,8 +11,12 @@ services:
     environment:
       - INFLUXDB_DB=${INFLUXDB_DB}
       - INFLUXDB_HTTP_AUTH_ENABLED=${INFLUXDB_HTTP_AUTH_ENABLED}
-      - INFLUXDB_ADMIN_USER=${INFLUXDB_ADMIN_USER}
-      - INFLUXDB_ADMIN_PASSWORD=${INFLUXDB_ADMIN_PASSWORD}
+      - DOCKER_INFLUXDB_INIT_MODE=setup
+      - DOCKER_INFLUXDB_INIT_USERNAME=${INFLUXDB_ADMIN_USER}
+      - DOCKER_INFLUXDB_INIT_PASSWORD=${INFLUXDB_ADMIN_PASSWORD}
+      - DOCKER_INFLUXDB_INIT_ORG=${INFLUXDB_ORG}
+      - DOCKER_INFLUXDB_INIT_BUCKET=${INFLUXDB_BUCKET}
+      - DOCKER_INFLUXDB_INIT_ADMIN_TOKEN=${INFLUXDB_ADMIN_TOKEN}
   chronograf:
     image: chronograf:latest
     restart: always
@@ -42,10 +46,17 @@ services:
   unifi-poller:
     restart: always
     image: ghcr.io/unpoller/unpoller:${POLLER_TAG}
+    depends_on:
+      - grafana
+      - influxdb
+      - chronograf
     environment:
       - UP_INFLUXDB_DB=${INFLUXDB_DB}
       - UP_INFLUXDB_USER=${INFLUXDB_ADMIN_USER}
       - UP_INFLUXDB_PASS=${INFLUXDB_ADMIN_PASSWORD}
+      - UP_INFLUXDB_ORG=${INFLUXDB_ORG}
+      - UP_INFLUXDB_BUCKET=${INFLUXDB_BUCKET}
+      - UP_INFLUXDB_AUTH_TOKEN=${INFLUXDB_ADMIN_TOKEN}
       - UP_INFLUXDB_URL=http://influxdb:8086
       - UP_UNIFI_DEFAULT_USER=${UNIFI_USER}
       - UP_UNIFI_DEFAULT_PASS=${UNIFI_PASS}

--- a/pkg/datadogunifi/datadog.go
+++ b/pkg/datadogunifi/datadog.go
@@ -197,9 +197,6 @@ func (u *DatadogUnifi) Enabled() bool {
 	if u.Enable == nil || u.Config == nil {
 		return false
 	}
-	if u.Collector == nil {
-		return false
-	}
 	return *u.Enable
 }
 
@@ -207,10 +204,10 @@ func (u *DatadogUnifi) Enabled() bool {
 func (u *DatadogUnifi) Run(c poller.Collect) error {
 	u.Collector = c
 	if !u.Enabled() {
-		u.Logf("DataDog config missing (or disabled), DataDog output disabled!")
+		u.LogDebugf("DataDog config missing (or disabled), DataDog output disabled!")
 		return nil
 	}
-	u.Logf("Datadog is configured.")
+	u.Logf("Datadog is enabled")
 	u.setConfigDefaults()
 
 	var err error

--- a/pkg/lokiunifi/loki.go
+++ b/pkg/lokiunifi/loki.go
@@ -70,16 +70,20 @@ func (l *Loki) Enabled() bool {
 	if l.Config == nil {
 		return false
 	}
+	if l.URL == "" {
+		return false
+	}
 	return !l.Disable
 }
 
 // Run is fired from the poller library after the Config is unmarshalled.
 func (l *Loki) Run(collect poller.Collect) error {
 	l.Collect = collect
-	if l.Config == nil || l.URL == "" || !l.Enabled() {
-		l.Logf("Loki config missing (or disabled), Loki output disabled!")
+	if !l.Enabled() {
+		l.LogDebugf("Loki config missing (or disabled), Loki output disabled!")
 		return nil
 	}
+	l.Logf("Loki enabled")
 
 	l.ValidateConfig()
 

--- a/pkg/poller/config.go
+++ b/pkg/poller/config.go
@@ -33,10 +33,10 @@ func DefaultConfFile() string {
 	case "netbsd":
 		fallthrough
 	case "openbsd":
-		return "/etc/unifi-poller/up.conf,/usr/local/etc/unifi-poller/up.conf"
+		return "/etc/unpoller/up.conf,/etc/unifi-poller/up.conf,/usr/local/etc/unifi-poller/up.conf"
 	default:
 		// linux and everything else
-		return "/config/unifi-poller.conf,/etc/unifi-poller/up.conf"
+		return "/etc/unpoller/up.conf,/config/unifi-poller.conf,/etc/unifi-poller/up.conf"
 	}
 }
 

--- a/pkg/poller/inputs.go
+++ b/pkg/poller/inputs.go
@@ -63,9 +63,12 @@ func (u *UnifiPoller) InitializeInputs() error {
 
 	for _, input := range inputs {
 		// This must return, or the app locks up here.
+		u.LogDebugf("inititalizing input... %s", input.Name)
 		if err := input.Initialize(u); err != nil {
+			u.LogDebugf("error initializing input ... %s", input.Name)
 			return err
 		}
+		u.LogDebugf("input successfully initialized ... %s", input.Name)
 	}
 
 	return nil

--- a/pkg/poller/outputs.go
+++ b/pkg/poller/outputs.go
@@ -87,9 +87,12 @@ func (u *UnifiPoller) runOutputMethods() (int, chan error) {
 
 	for _, o := range outputs {
 		if o != nil && o.Enabled() {
+			u.LogDebugf("output plugin enabled, starting run loop for %s", o.Name)
 			go func(o *Output) {
 				err <- o.Run(u) // Run each output plugin
 			}(o)
+		} else {
+			u.LogDebugf("output plugin disabled for %s", o.Name)
 		}
 	}
 

--- a/pkg/poller/start.go
+++ b/pkg/poller/start.go
@@ -94,5 +94,7 @@ func (u *UnifiPoller) Run() error {
 		return err
 	}
 
+	u.LogDebugf("staring outputs")
+
 	return u.InitializeOutputs()
 }

--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -121,9 +121,6 @@ func (u *promUnifi) Enabled() bool {
 	if u.Config == nil {
 		return false
 	}
-	if u.Collector == nil {
-		return false
-	}
 	return !u.Disable
 }
 
@@ -132,9 +129,10 @@ func (u *promUnifi) Enabled() bool {
 func (u *promUnifi) Run(c poller.Collect) error {
 	u.Collector = c
 	if u.Config == nil || !u.Enabled() {
-		u.Logf("Prometheus config missing (or disabled), Prometheus HTTP listener disabled!")
+		u.LogDebugf("Prometheus config missing (or disabled), Prometheus HTTP listener disabled!")
 		return nil
 	}
+	u.Logf("Prometheus is enabled")
 
 	u.Namespace = strings.Trim(strings.ReplaceAll(u.Namespace, "-", "_"), "_")
 	if u.Namespace == "" {

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -73,9 +73,6 @@ func (s *Server) Enabled() bool {
 	if s.Config == nil {
 		return false
 	}
-	if s.Collect == nil {
-		return false
-	}
 	return s.Enable
 }
 
@@ -83,9 +80,10 @@ func (s *Server) Enabled() bool {
 func (s *Server) Run(c poller.Collect) error {
 	s.Collect = c
 	if s.Config == nil || s.Port == 0 || s.HTMLPath == "" || !s.Enabled() {
-		s.Logf("Internal web server disabled!")
+		s.LogDebugf("Internal web server disabled!")
 		return nil
 	}
+	s.Logf("Internal web server enabled")
 
 	if _, err := os.Stat(s.HTMLPath); err != nil {
 		return fmt.Errorf("problem with HTML path: %w", err)


### PR DESCRIPTION
- fix the default missing config based off example config, this was affecting #443
- also fixes packages to `noreplace` a default config for new installs.
- fixes a bug introduced in 2.4.0 before collectors were set making some plugins false disabled