### PR TITLE
restore lost version info after goreleaser change

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -16,6 +16,8 @@ builds:
     goarch:
       - amd64
       - "386"
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X "golift.io/version.Version={{.Version}}" -X "golift.io/version.Branch={{.Branch}} ({{.Commit}})" -X "golift.io/version.BuildDate={{.Date}}" -X "golift.io/version.BuildUser=goreleaser" -X "golift.io/version.Revision=1"
     ignore:
       - goamd64: v4
       - goos: freebsd
@@ -29,6 +31,8 @@ builds:
     goarch:
       - amd64
       - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X "golift.io/version.Version={{.Version}}" -X "golift.io/version.Branch={{.Branch}} ({{.Commit}})" -X "golift.io/version.BuildDate={{.Date}}" -X "golift.io/version.BuildUser=goreleaser" -X "golift.io/version.Revision=1"
     ignore:
       - goos: darwin
         goarch: "386"
@@ -44,6 +48,8 @@ builds:
     goarch:
       - arm64
       - arm
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X "golift.io/version.Version={{.Version}}" -X "golift.io/version.Branch={{.Branch}} ({{.Commit}})" -X "golift.io/version.BuildDate={{.Date}}" -X "golift.io/version.BuildUser=goreleaser" -X "golift.io/version.Revision=1"
   - id: unpoller-windows
     env:
       - CGO_ENABLED=0
@@ -52,6 +58,8 @@ builds:
       - windows
     goarch:
       - amd64
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}} -X main.builtBy=goreleaser -X "golift.io/version.Version={{.Version}}" -X "golift.io/version.Branch={{.Branch}} ({{.Commit}})" -X "golift.io/version.BuildDate={{.Date}}" -X "golift.io/version.BuildUser=goreleaser" -X "golift.io/version.Revision=1"
 
 archives:
   - id: unpoller


### PR DESCRIPTION
Restores the build info from when we switched to goreleaser:

Example on local build: 

```
> ./dist/unpoller-mac_darwin_amd64_v1/unpoller -v
unpoller, version 2.4.2 (branch: master (08a3c1d66baaeaaadd64e17961beffc5e669a958), revision: 1)
  build user:       goreleaser
  build date:       2022-12-21T01:53:38Z
  go version:       go1.19.4
  platform:         darwin/amd64
  started:          2022-12-20 19:54:04.136784 -0600 CST m=+0.001716085
```
