### PR TITLE
"Upgradeable" metrics addition

### DIFF
--- a/pkg/datadogunifi/points.go
+++ b/pkg/datadogunifi/points.go
@@ -47,3 +47,10 @@ func cleanTags(tags map[string]string) map[string]string {
 
 	return tags
 }
+
+func boolToFloat64(v bool) float64 {
+	if v {
+		return 1.0
+	}
+	return 0.0
+}

--- a/pkg/datadogunifi/uap.go
+++ b/pkg/datadogunifi/uap.go
@@ -70,6 +70,7 @@ func (u *DatadogUnifi) batchUAP(r report, s *unifi.UAP) {
 	data["user_num_sta"] = s.UserNumSta.Val
 	data["guest_num_sta"] = s.GuestNumSta.Val
 	data["num_sta"] = s.NumSta.Val
+	data["upgradeable"] = boolToFloat64(s.Upgradable.Val)
 
 	r.addCount(uapT)
 

--- a/pkg/datadogunifi/udm.go
+++ b/pkg/datadogunifi/udm.go
@@ -125,6 +125,7 @@ func (u *DatadogUnifi) batchUDM(r report, s *unifi.UDM) { // nolint: funlen
 			"num_desktop":   s.NumDesktop.Val,
 			"num_handheld":  s.NumHandheld.Val,
 			"num_mobile":    s.NumMobile.Val,
+			"upgradeable":   boolToFloat64(s.Upgradeable.Val),
 		},
 	)
 
@@ -155,6 +156,7 @@ func (u *DatadogUnifi) batchUDM(r report, s *unifi.UDM) { // nolint: funlen
 			"rx_bytes":      s.RxBytes.Val,
 			"tx_bytes":      s.TxBytes.Val,
 			"uptime":        s.Uptime.Val,
+			"upgradeable":   boolToFloat64(s.Upgradeable.Val),
 		})
 
 	metricName = metricNamespace("usw")

--- a/pkg/datadogunifi/usg.go
+++ b/pkg/datadogunifi/usg.go
@@ -42,6 +42,7 @@ func (u *DatadogUnifi) batchUSG(r report, s *unifi.USG) {
 			"num_desktop":   s.NumDesktop.Val,
 			"num_handheld":  s.NumHandheld.Val,
 			"num_mobile":    s.NumMobile.Val,
+			"upgradeable":   boolToFloat64(s.Upgradable.Val),
 		},
 	)
 

--- a/pkg/datadogunifi/usw.go
+++ b/pkg/datadogunifi/usw.go
@@ -39,6 +39,7 @@ func (u *DatadogUnifi) batchUSW(r report, s *unifi.USW) {
 			"uptime":              s.Uptime.Val,
 			"state":               s.State.Val,
 			"user_num_sta":        s.UserNumSta.Val,
+			"upgradeable":         boolToFloat64(s.Upgradeable.Val),
 		})
 
 	r.addCount(uswT)

--- a/pkg/influxunifi/uap.go
+++ b/pkg/influxunifi/uap.go
@@ -68,6 +68,7 @@ func (u *InfluxUnifi) batchUAP(r report, s *unifi.UAP) {
 	fields["user-num_sta"] = int(s.UserNumSta.Val)
 	fields["guest-num_sta"] = int(s.GuestNumSta.Val)
 	fields["num_sta"] = s.NumSta.Val
+	fields["upgradeable"] = s.Upgradable.Val
 
 	r.addCount(uapT)
 	r.send(&metric{Table: "uap", Tags: tags, Fields: fields})

--- a/pkg/influxunifi/udm.go
+++ b/pkg/influxunifi/udm.go
@@ -114,6 +114,7 @@ func (u *InfluxUnifi) batchUDM(r report, s *unifi.UDM) { // nolint: funlen
 			"num_desktop":   s.NumDesktop.Val,
 			"num_handheld":  s.NumHandheld.Val,
 			"num_mobile":    s.NumMobile.Val,
+			"upgradeable":   s.Upgradeable.Val,
 		},
 	)
 
@@ -142,6 +143,7 @@ func (u *InfluxUnifi) batchUDM(r report, s *unifi.UDM) { // nolint: funlen
 			"rx_bytes":      s.RxBytes.Val,
 			"tx_bytes":      s.TxBytes.Val,
 			"uptime":        s.Uptime.Val,
+			"upgradeable":   s.Upgradeable.Val,
 		})
 
 	r.send(&metric{Table: "usw", Tags: tags, Fields: fields})

--- a/pkg/influxunifi/usg.go
+++ b/pkg/influxunifi/usg.go
@@ -43,6 +43,7 @@ func (u *InfluxUnifi) batchUSG(r report, s *unifi.USG) {
 			"num_desktop":   s.NumDesktop.Val,
 			"num_handheld":  s.NumHandheld.Val,
 			"num_mobile":    s.NumMobile.Val,
+			"upgradeable":   s.Upgradable.Val,
 			//			"speedtest_rundate": time.Unix(int64(s.SpeedtestStatus.Rundate.Val), 0).String(),
 		},
 	)

--- a/pkg/influxunifi/usw.go
+++ b/pkg/influxunifi/usw.go
@@ -39,6 +39,7 @@ func (u *InfluxUnifi) batchUSW(r report, s *unifi.USW) {
 			"uptime":              s.Uptime.Val,
 			"state":               s.State.Val,
 			"user-num_sta":        s.UserNumSta.Val,
+			"upgradeable":         s.Upgradable.Val,
 		})
 
 	r.addCount(uswT)

--- a/pkg/promunifi/udm.go
+++ b/pkg/promunifi/udm.go
@@ -29,6 +29,7 @@ type unifiDevice struct {
 	MemUsed       *prometheus.Desc
 	CPU           *prometheus.Desc
 	Mem           *prometheus.Desc
+	Upgradeable   *prometheus.Desc
 }
 
 func descDevice(ns string) *unifiDevice {
@@ -60,6 +61,7 @@ func descDevice(ns string) *unifiDevice {
 		MemBuffer:     prometheus.NewDesc(ns+"memory_buffer_bytes", "System Memory Buffer", labels, nil),
 		CPU:           prometheus.NewDesc(ns+"cpu_utilization_ratio", "System CPU % Utilized", labels, nil),
 		Mem:           prometheus.NewDesc(ns+"memory_utilization_ratio", "System Memory % Utilized", labels, nil),
+		Upgradeable:   prometheus.NewDesc(ns+"upgradable", "Upgrade-able", labels, nil),
 	}
 }
 
@@ -85,6 +87,7 @@ func (u *promUnifi) exportUDM(r report, d *unifi.UDM) {
 	r.send([]*metric{
 		{u.Device.Info, gauge, 1.0, append(labels, infoLabels...)},
 		{u.Device.Uptime, gauge, d.Uptime, labels},
+		{u.Device.Upgradeable, gauge, d.Upgradeable.Val, labels},
 	})
 
 	// UDM pro has special temp sensors. UDM non-pro may not have temp; not sure.

--- a/pkg/promunifi/usg.go
+++ b/pkg/promunifi/usg.go
@@ -104,6 +104,7 @@ func (u *promUnifi) exportUSG(r report, d *unifi.USG) {
 	r.send([]*metric{
 		{u.Device.Info, gauge, 1.0, append(labels, infoLabels...)},
 		{u.Device.Uptime, gauge, d.Uptime, labels},
+		{u.Device.Upgradeable, gauge, d.Upgradable.Val, labels},
 	})
 }
 

--- a/pkg/promunifi/usw.go
+++ b/pkg/promunifi/usw.go
@@ -48,6 +48,8 @@ type usw struct {
 	SFPTemperature *prometheus.Desc
 	SFPTxPower     *prometheus.Desc
 	SFPVoltage     *prometheus.Desc
+	// other
+	Upgradeable *prometheus.Desc
 }
 
 func descUSW(ns string) *usw {
@@ -104,6 +106,8 @@ func descUSW(ns string) *usw {
 		SFPTemperature: nd(sfp+"temperature", "SFP Temperature", labelF, nil),
 		SFPTxPower:     nd(sfp+"tx_power", "SFP Transmit Power", labelF, nil),
 		SFPVoltage:     nd(sfp+"voltage", "SFP Voltage", labelF, nil),
+		// other data
+		Upgradeable: nd(ns+"upgradeable", "Upgrade-able", labelS, nil),
 	}
 }
 
@@ -123,6 +127,7 @@ func (u *promUnifi) exportUSW(r report, d *unifi.USW) {
 	r.send([]*metric{
 		{u.Device.Info, gauge, 1.0, append(labels, infoLabels...)},
 		{u.Device.Uptime, gauge, d.Uptime, labels},
+		{u.Device.Upgradeable, gauge, d.Upgradable.Val, labels},
 	})
 
 	// Switch System Data.


### PR DESCRIPTION
- report upgrade metrics for #433

This is returned as a boolean value, so report respectively for each output plugin type (datadog and prometheus this is a numeric representation 1=true, 0=false, influx this is the string form)