### PR TITLE
Adds DebugIO option to CLI

### DIFF
--- a/pkg/datadogunifi/datadog.go
+++ b/pkg/datadogunifi/datadog.go
@@ -3,6 +3,7 @@
 package datadogunifi
 
 import (
+	"fmt"
 	"reflect"
 	"time"
 
@@ -201,6 +202,22 @@ func (u *DatadogUnifi) Enabled() bool {
 		return false
 	}
 	return *u.Enable
+}
+
+func (u *DatadogUnifi) DebugOutput(l poller.Logger) (bool, error) {
+	if u == nil {
+		return true, nil
+	}
+	if !u.Enabled() {
+		return true, nil
+	}
+	u.setConfigDefaults()
+	var err error
+	u.datadog, err = statsd.New(u.Address, u.options...)
+	if err != nil {
+		return false, fmt.Errorf("Error configuration Datadog agent reporting: %+v", err)
+	}
+	return true, nil
 }
 
 // Run runs a ticker to poll the unifi server and update Datadog.

--- a/pkg/datadogunifi/datadog.go
+++ b/pkg/datadogunifi/datadog.go
@@ -204,7 +204,7 @@ func (u *DatadogUnifi) Enabled() bool {
 	return *u.Enable
 }
 
-func (u *DatadogUnifi) DebugOutput(l poller.Logger) (bool, error) {
+func (u *DatadogUnifi) DebugOutput() (bool, error) {
 	if u == nil {
 		return true, nil
 	}

--- a/pkg/influxunifi/influxdb.go
+++ b/pkg/influxunifi/influxdb.go
@@ -143,7 +143,7 @@ func (u *InfluxUnifi) Enabled() bool {
 	return !u.Disable
 }
 
-func (u *InfluxUnifi) DebugOutput(l poller.Logger) (bool, error) {
+func (u *InfluxUnifi) DebugOutput() (bool, error) {
 	if u == nil {
 		return true, nil
 	}

--- a/pkg/influxunifi/influxdb.go
+++ b/pkg/influxunifi/influxdb.go
@@ -16,6 +16,7 @@ import (
 	"github.com/unpoller/unifi"
 	"github.com/unpoller/unpoller/pkg/poller"
 	"github.com/unpoller/unpoller/pkg/webserver"
+	"golang.org/x/net/context"
 	"golift.io/cnfg"
 )
 
@@ -140,6 +141,51 @@ func (u *InfluxUnifi) Enabled() bool {
 		return false
 	}
 	return !u.Disable
+}
+
+func (u *InfluxUnifi) DebugOutput(l poller.Logger) (bool, error) {
+	if u == nil {
+		return true, nil
+	}
+	if !u.Enabled() {
+		return true, nil
+	}
+	u.setConfigDefaults()
+	_, err := url.Parse(u.Config.URL)
+	if err != nil {
+		return false, fmt.Errorf("invalid influx URL: %v", err)
+	}
+
+	if u.IsVersion2 {
+		// we're a version 2
+		tlsConfig := &tls.Config{InsecureSkipVerify: !u.VerifySSL} // nolint: gosec
+		serverOptions := influx.DefaultOptions().SetTLSConfig(tlsConfig).SetBatchSize(u.BatchSize)
+		u.influxV2 = influx.NewClientWithOptions(u.URL, u.AuthToken, serverOptions)
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*2)
+		defer cancel()
+		ok, err := u.influxV2.Ping(ctx)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			return false, fmt.Errorf("unsuccessful ping to influxdb2")
+		}
+	} else {
+		u.influxV1, err = influxV1.NewHTTPClient(influxV1.HTTPConfig{
+			Addr:      u.URL,
+			Username:  u.User,
+			Password:  u.Pass,
+			TLSConfig: &tls.Config{InsecureSkipVerify: !u.VerifySSL}, // nolint: gosec
+		})
+		if err != nil {
+			return false, fmt.Errorf("making client: %w", err)
+		}
+		_, _, err = u.influxV1.Ping(time.Second * 2)
+		if err != nil {
+			return false, fmt.Errorf("unsuccessful ping to influxdb1")
+		}
+	}
+	return true, nil
 }
 
 // Run runs a ticker to poll the unifi server and update influxdb.

--- a/pkg/influxunifi/logger.go
+++ b/pkg/influxunifi/logger.go
@@ -14,7 +14,9 @@ func (u *InfluxUnifi) Logf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "info"},
 	})
-	u.Collector.Logf(msg, v...)
+	if u.Collector != nil {
+		u.Collector.Logf(msg, v...)
+	}
 }
 
 // LogErrorf logs an error message.
@@ -24,7 +26,9 @@ func (u *InfluxUnifi) LogErrorf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "error"},
 	})
-	u.Collector.LogErrorf(msg, v...)
+	if u.Collector != nil {
+		u.Collector.LogErrorf(msg, v...)
+	}
 }
 
 // LogDebugf logs a debug message.
@@ -34,5 +38,7 @@ func (u *InfluxUnifi) LogDebugf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "debug"},
 	})
-	u.Collector.LogDebugf(msg, v...)
+	if u.Collector != nil {
+		u.Collector.LogDebugf(msg, v...)
+	}
 }

--- a/pkg/inputunifi/updateweb.go
+++ b/pkg/inputunifi/updateweb.go
@@ -191,7 +191,9 @@ func (u *InputUnifi) Logf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "info"},
 	})
-	u.Logger.Logf(msg, v...)
+	if u.Logger != nil {
+		u.Logger.Logf(msg, v...)
+	}
 }
 
 // LogErrorf logs an error message.
@@ -201,7 +203,9 @@ func (u *InputUnifi) LogErrorf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "error"},
 	})
-	u.Logger.LogErrorf(msg, v...)
+	if u.Logger != nil {
+		u.Logger.LogErrorf(msg, v...)
+	}
 }
 
 // LogDebugf logs a debug message.
@@ -211,5 +215,7 @@ func (u *InputUnifi) LogDebugf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "debug"},
 	})
-	u.Logger.LogDebugf(msg, v...)
+	if u.Logger != nil {
+		u.Logger.LogDebugf(msg, v...)
+	}
 }

--- a/pkg/lokiunifi/logger.go
+++ b/pkg/lokiunifi/logger.go
@@ -14,7 +14,9 @@ func (l *Loki) Logf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "info"},
 	})
-	l.Collect.Logf(msg, v...)
+	if l.Collect != nil {
+		l.Collect.Logf(msg, v...)
+	}
 }
 
 // LogErrorf logs an error message.
@@ -24,7 +26,9 @@ func (l *Loki) LogErrorf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "error"},
 	})
-	l.Collect.LogErrorf(msg, v...)
+	if l.Collect != nil {
+		l.Collect.LogErrorf(msg, v...)
+	}
 }
 
 // LogDebugf logs a debug message.
@@ -34,5 +38,7 @@ func (l *Loki) LogDebugf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "debug"},
 	})
-	l.Collect.LogDebugf(msg, v...)
+	if l.Collect != nil {
+		l.Collect.LogDebugf(msg, v...)
+	}
 }

--- a/pkg/lokiunifi/loki.go
+++ b/pkg/lokiunifi/loki.go
@@ -76,7 +76,7 @@ func (l *Loki) Enabled() bool {
 	return !l.Disable
 }
 
-func (l *Loki) DebugOutput(logger poller.Logger) (bool, error) {
+func (l *Loki) DebugOutput() (bool, error) {
 	if l == nil {
 		return true, nil
 	}

--- a/pkg/lokiunifi/loki.go
+++ b/pkg/lokiunifi/loki.go
@@ -76,6 +76,19 @@ func (l *Loki) Enabled() bool {
 	return !l.Disable
 }
 
+func (l *Loki) DebugOutput(logger poller.Logger) (bool, error) {
+	if l == nil {
+		return true, nil
+	}
+	if !l.Enabled() {
+		return true, nil
+	}
+	if err := l.ValidateConfig(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // Run is fired from the poller library after the Config is unmarshalled.
 func (l *Loki) Run(collect poller.Collect) error {
 	l.Collect = collect
@@ -85,7 +98,10 @@ func (l *Loki) Run(collect poller.Collect) error {
 	}
 	l.Logf("Loki enabled")
 
-	l.ValidateConfig()
+	if err := l.ValidateConfig(); err != nil {
+		l.LogErrorf("invalid loki config")
+		return err
+	}
 
 	fake := *l.Config
 	fake.Password = strconv.FormatBool(fake.Password != "")
@@ -99,7 +115,7 @@ func (l *Loki) Run(collect poller.Collect) error {
 
 // ValidateConfig sets initial "last" update time. Also creates an http client,
 // makes sure URL is sane, and sets interval within min/max limits.
-func (l *Loki) ValidateConfig() {
+func (l *Loki) ValidateConfig() error {
 	if l.Interval.Duration > maxInterval {
 		l.Interval.Duration = maxInterval
 	} else if l.Interval.Duration < minInterval {
@@ -110,6 +126,7 @@ func (l *Loki) ValidateConfig() {
 		pass, err := os.ReadFile(strings.TrimPrefix(l.Password, "file://"))
 		if err != nil {
 			l.LogErrorf("Reading Loki Password File: %v", err)
+			return fmt.Errorf("error reading password file")
 		}
 
 		l.Password = strings.TrimSpace(string(pass))
@@ -118,6 +135,7 @@ func (l *Loki) ValidateConfig() {
 	l.last = time.Now().Add(-l.Interval.Duration)
 	l.client = l.httpClient()
 	l.URL = strings.TrimRight(l.URL, "/") // gets a path appended to it later.
+	return nil
 }
 
 // PollController runs forever, polling UniFi for events and pushing them to Loki.

--- a/pkg/lokiunifi/report_ids.go
+++ b/pkg/lokiunifi/report_ids.go
@@ -15,7 +15,7 @@ func (r *Report) IDS(event *unifi.IDS, logs *Logs) {
 	}
 
 	r.Counts[typeIDS]++ // increase counter and append new log line.
-	
+
 	logs.Streams = append(logs.Streams, LogStream{
 		Entries: [][]string{{strconv.FormatInt(event.Datetime.UnixNano(), 10), event.Msg}},
 		Labels: CleanLabels(map[string]string{

--- a/pkg/mysqlunifi/main.go
+++ b/pkg/mysqlunifi/main.go
@@ -69,7 +69,7 @@ func (p *plugin) Enabled() bool {
 	return !p.Disable
 }
 
-func (p *plugin) DebugOutput(l poller.Logger) (bool, error) {
+func (p *plugin) DebugOutput() (bool, error) {
 	if p == nil {
 		return true, nil
 	}

--- a/pkg/mysqlunifi/main.go
+++ b/pkg/mysqlunifi/main.go
@@ -69,6 +69,19 @@ func (p *plugin) Enabled() bool {
 	return !p.Disable
 }
 
+func (p *plugin) DebugOutput(l poller.Logger) (bool, error) {
+	if p == nil {
+		return true, nil
+	}
+	if !p.Enabled() {
+		return true, nil
+	}
+	if err := p.validateConfig(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 // Run gets called by poller core code. Return when the plugin stops working or has an error.
 // In other words, don't run your code in a go routine, it already is.
 func (p *plugin) Run(c poller.Collect) error {

--- a/pkg/poller/config.go
+++ b/pkg/poller/config.go
@@ -72,6 +72,7 @@ type Flags struct {
 	DumpJSON   string
 	HashPW     string
 	ShowVer    bool
+	DebugIO    bool
 	*pflag.FlagSet
 }
 

--- a/pkg/poller/inputs.go
+++ b/pkg/poller/inputs.go
@@ -21,7 +21,7 @@ type Input interface {
 	Metrics(*Filter) (*Metrics, error) // Called every time new metrics are requested.
 	Events(*Filter) (*Events, error)   // This is new.
 	RawMetrics(*Filter) ([]byte, error)
-	DebugInputs(Logger) (bool, error)
+	DebugInput() (bool, error)
 }
 
 // InputPlugin describes an input plugin's consumable interface.

--- a/pkg/poller/inputs.go
+++ b/pkg/poller/inputs.go
@@ -21,6 +21,7 @@ type Input interface {
 	Metrics(*Filter) (*Metrics, error) // Called every time new metrics are requested.
 	Events(*Filter) (*Events, error)   // This is new.
 	RawMetrics(*Filter) ([]byte, error)
+	DebugInputs(Logger) (bool, error)
 }
 
 // InputPlugin describes an input plugin's consumable interface.

--- a/pkg/poller/outputs.go
+++ b/pkg/poller/outputs.go
@@ -27,6 +27,7 @@ type Collect interface {
 type OutputPlugin interface {
 	Run(Collect) error
 	Enabled() bool
+	DebugOutput(Logger) (bool, error)
 }
 
 // Output defines the output data for a metric exporter like influx or prometheus.

--- a/pkg/poller/outputs.go
+++ b/pkg/poller/outputs.go
@@ -27,7 +27,7 @@ type Collect interface {
 type OutputPlugin interface {
 	Run(Collect) error
 	Enabled() bool
-	DebugOutput(Logger) (bool, error)
+	DebugOutput() (bool, error)
 }
 
 // Output defines the output data for a metric exporter like influx or prometheus.

--- a/pkg/poller/start.go
+++ b/pkg/poller/start.go
@@ -48,6 +48,15 @@ func (u *UnifiPoller) Start() error {
 		return err
 	}
 
+	if u.Flags.DebugIO {
+		err = u.DebugIO()
+		if err != nil {
+			os.Exit(1)
+		}
+		log.Fatal("Failed debug checks")
+		return err
+	}
+
 	return u.Run()
 }
 
@@ -63,6 +72,7 @@ func (f *Flags) Parse(args []string) {
 		"This option bcrypts a provided string. Useful for the webserver password. Use - to be prompted.")
 	f.StringVarP(&f.DumpJSON, "dumpjson", "j", "",
 		"This debug option prints a json payload and exits. See man page for more info.")
+	f.BoolVarP(&f.DebugIO, "debugio", "d", false, "Debug the Inputs and Outputs configured and exit.")
 	f.StringVarP(&f.ConfigFile, "config", "c", DefaultConfFile(),
 		"Poller config file path. Separating multiple paths with a comma will load the first config file found.")
 	f.BoolVarP(&f.ShowVer, "version", "v", false, "Print the version and exit.")

--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -3,7 +3,9 @@ package promunifi
 
 import (
 	"fmt"
+	"net"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"sync"
@@ -114,6 +116,29 @@ func init() { // nolint: gochecknoinits
 		Config:       u,
 		OutputPlugin: u,
 	})
+}
+
+func (u *promUnifi) DebugOutput(l poller.Logger) (bool, error) {
+	if u == nil {
+		return true, nil
+	}
+	if !u.Enabled() {
+		return true, nil
+	}
+	if u.HTTPListen == "" {
+		return false, fmt.Errorf("invalid listen string")
+	}
+	// check the port
+	httpListenURL, err := url.Parse(u.HTTPListen)
+	if err != nil {
+		return false, err
+	}
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%s", httpListenURL.Host, httpListenURL.Port()))
+	if err != nil {
+		return false, err
+	}
+	_ = ln.Close()
+	return false, nil
 }
 
 func (u *promUnifi) Enabled() bool {

--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"reflect"
 	"strings"
 	"sync"
@@ -118,7 +117,7 @@ func init() { // nolint: gochecknoinits
 	})
 }
 
-func (u *promUnifi) DebugOutput(l poller.Logger) (bool, error) {
+func (u *promUnifi) DebugOutput() (bool, error) {
 	if u == nil {
 		return true, nil
 	}
@@ -129,16 +128,17 @@ func (u *promUnifi) DebugOutput(l poller.Logger) (bool, error) {
 		return false, fmt.Errorf("invalid listen string")
 	}
 	// check the port
-	httpListenURL, err := url.Parse(u.HTTPListen)
-	if err != nil {
-		return false, err
+	parts := strings.Split(u.HTTPListen, ":")
+	if len(parts) != 2 {
+		return false, fmt.Errorf("invalid listen address: %s (must be of the form \"IP:Port\"", u.HTTPListen)
 	}
-	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%s", httpListenURL.Host, httpListenURL.Port()))
+
+	ln, err := net.Listen("tcp", u.HTTPListen)
 	if err != nil {
 		return false, err
 	}
 	_ = ln.Close()
-	return false, nil
+	return true, nil
 }
 
 func (u *promUnifi) Enabled() bool {

--- a/pkg/promunifi/logger.go
+++ b/pkg/promunifi/logger.go
@@ -14,7 +14,9 @@ func (u *promUnifi) Logf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "info"},
 	})
-	u.Collector.Logf(msg, v...)
+	if u.Collector != nil {
+		u.Collector.Logf(msg, v...)
+	}
 }
 
 // LogErrorf logs an error message.
@@ -24,7 +26,9 @@ func (u *promUnifi) LogErrorf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "error"},
 	})
-	u.Collector.LogErrorf(msg, v...)
+	if u.Collector != nil {
+		u.Collector.LogErrorf(msg, v...)
+	}
 }
 
 // LogDebugf logs a debug message.
@@ -34,5 +38,7 @@ func (u *promUnifi) LogDebugf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "debug"},
 	})
-	u.Collector.LogDebugf(msg, v...)
+	if u.Collector != nil {
+		u.Collector.LogDebugf(msg, v...)
+	}
 }

--- a/pkg/webserver/logger.go
+++ b/pkg/webserver/logger.go
@@ -12,7 +12,9 @@ func (s *Server) Logf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "info"},
 	})
-	s.Collect.Logf(msg, v...)
+	if s.Collect != nil {
+		s.Collect.Logf(msg, v...)
+	}
 }
 
 // LogErrorf logs an error message.
@@ -22,7 +24,9 @@ func (s *Server) LogErrorf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "error"},
 	})
-	s.Collect.LogErrorf(msg, v...)
+	if s.Collect != nil {
+		s.Collect.LogErrorf(msg, v...)
+	}
 }
 
 // LogDebugf logs a debug message.
@@ -32,5 +36,7 @@ func (s *Server) LogDebugf(msg string, v ...any) {
 		Msg:  fmt.Sprintf(msg, v...),
 		Tags: map[string]string{"type": "debug"},
 	})
-	s.Collect.LogDebugf(msg, v...)
+	if s.Collect != nil {
+		s.Collect.LogDebugf(msg, v...)
+	}
 }

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -95,7 +95,7 @@ func (s *Server) Run(c poller.Collect) error {
 	return s.Start()
 }
 
-func (s *Server) DebugOutput(l poller.Logger) (bool, error) {
+func (s *Server) DebugOutput() (bool, error) {
 	if s == nil {
 		return true, nil
 	}

--- a/pkg/webserver/server.go
+++ b/pkg/webserver/server.go
@@ -4,6 +4,7 @@ package webserver
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -92,6 +93,32 @@ func (s *Server) Run(c poller.Collect) error {
 	UpdateOutput(&Output{Name: PluginName, Config: s.Config})
 
 	return s.Start()
+}
+
+func (s *Server) DebugOutput(l poller.Logger) (bool, error) {
+	if s == nil {
+		return true, nil
+	}
+	if !s.Enabled() {
+		return true, nil
+	}
+	if s.HTMLPath == "" {
+		return true, nil
+	}
+
+	// check the html path
+	if _, err := os.Stat(s.HTMLPath); err != nil {
+		return false, fmt.Errorf("problem with HTML path: %w", err)
+	}
+
+	// check the port
+	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", s.Port))
+	if err != nil {
+		return false, err
+	}
+	_ = ln.Close()
+
+	return true, nil
 }
 
 // Start gets the web server going.


### PR DESCRIPTION
fixes #471 

Adds debugIO option to help aid in some basic checks.

Looks like this

```bash
unpoller -d -c /my/home/unpoller.conf
2022/12/22 18:15:52 [INFO] Loading Configuration File: /my/home/unpoller.conf
2022/12/22 18:15:52 [INFO] Checking inputs...
2022/12/22 18:15:52 [INFO] 	(1/1) Checking input unifi...
2022/12/22 18:15:53 [ERROR] 		 unifi Failed: unifi controller: making request: Get "https://1.2.3.4:443/": dial tcp 1.2.3.4:443: connect: connection refused
2022/12/22 18:15:53 [INFO] Checking outputs...
2022/12/22 18:15:53 [INFO] 	(1/5) Checking output WebServer...
2022/12/22 18:15:53 [INFO] 		 WebServer is OK
2022/12/22 18:15:53 [INFO] 	(2/5) Checking output datadog...
2022/12/22 18:15:53 [INFO] 		 datadog is OK
2022/12/22 18:15:53 [INFO] 	(3/5) Checking output influxdb...
2022/12/22 18:15:53 [INFO] 		 influxdb is OK
2022/12/22 18:15:53 [INFO] 	(4/5) Checking output loki...
2022/12/22 18:15:53 [INFO] 		 loki is OK
2022/12/22 18:15:53 [INFO] 	(5/5) Checking output prometheus...
2022/12/22 18:15:53 [INFO] 		 prometheus is OK
2022/12/22 18:15:53 [ERROR] No all checks passed, please fix the logged issues.
```