### PR TITLE
add homebrew auto generation to golift/homebrew-mugs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -407,6 +407,58 @@ universal_binaries:
     ids:
       - unpoller-mac
 
+brews:
+  - name: unpoller
+    ids:
+      - unpoller
+      - unpoller-linux-arm
+      - unpoller-mac
+    tap:
+      owner: golift
+      name: homebrew-mugs
+      branch: master
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    commit_author:
+      name: goreleaserbot
+      email: bot@goreleaser.com
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+    folder: Formula
+    # enable the line below only for testing locally
+    # skip_upload: true
+    homepage: https://unpoller.com/
+    description: "Polls a UniFi controller, exports metrics to InfluxDB, Prometheus and Datadog"
+    caveats: "Edit the config file at #{etc}/unpoller/up.conf then start unpoller with brew services start unpoller ~ log file: #{var}/log/unpoller.log The manual explains the config file options: man unpoller"
+    conflicts:
+      - unifi-poller
+    license: MIT
+    plist: |
+      <?xml version="1.0" encoding="UTF-8"?>
+      <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+      <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>#{plist_name}</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>#{bin}/unpoller</string>
+                <string>--config</string>
+                <string>#{etc}/unpoller/up.conf</string>
+            </array>
+            <key>RunAtLoad</key>
+            <true/>
+            <key>KeepAlive</key>
+            <true/>
+            <key>StandardErrorPath</key>
+            <string>#{var}/log/unpoller.log</string>
+            <key>StandardOutPath</key>
+            <string>#{var}/log/unpoller.log</string>
+        </dict>
+      </plist>
+    url_template: "https://github.com/unpoller/unpoller/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    test: |
+      assert_match "unpoller v#{version}", shell_output("#{bin}/unpoller -v 2>&1", 2)
+    
+
 publishers:
   - name: "packagecloud-publisher"
     ids:


### PR DESCRIPTION
This looks compatible with the previous formula and removes the need for build + upx as these are pre-built. 

generates this for the current 2.7.0 release:

```
# typed: false
# frozen_string_literal: true

# This file was generated by GoReleaser. DO NOT EDIT.
class Unpoller < Formula
  desc "Polls a UniFi controller, exports metrics to InfluxDB, Prometheus and Datadog"
  homepage "https://unpoller.com/"
  version "2.7.0"
  license "MIT"

  on_macos do
    url "https://github.com/unpoller/unpoller/releases/download/v2.7.0/unpoller_2.7.0_darwin_all.tar.gz"
    sha256 "2d12c4324e57c742a34b3a34b73a82702c88c2dd00d301229afc347a77e9fc1d"

    def install
      bin.install "unpoller"
    end
  end

  on_linux do
    if Hardware::CPU.arm? && !Hardware::CPU.is_64_bit?
      url "https://github.com/unpoller/unpoller/releases/download/v2.7.0/unpoller_2.7.0_linux_armv6.tar.gz"
      sha256 "bff633d67b473e9135b46b2e4565b64f6fb557fe5e0a3b4fbae8b5c88072a692"

      def install
        bin.install "unpoller"
      end
    end
    if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
      url "https://github.com/unpoller/unpoller/releases/download/v2.7.0/unpoller_2.7.0_linux_arm64.tar.gz"
      sha256 "4f0db21fee23e9c7664e9e968b99df5ed4aeda20971819c2abf4b6e139d331ee"

      def install
        bin.install "unpoller"
      end
    end
    if Hardware::CPU.intel?
      url "https://github.com/unpoller/unpoller/releases/download/v2.7.0/unpoller_2.7.0_linux_amd64.tar.gz"
      sha256 "c1418ec61b139c2de95d1a5a8d320b78cf27c6519f398ba4c80e1cc9683265c7"

      def install
        bin.install "unpoller"
      end
    end
  end

  conflicts_with "unifi-poller"

  def caveats
    <<~EOS
      Edit the config file at #{etc}/unpoller/up.conf then start unpoller with brew services start unpoller ~ log file: #{var}/log/unpoller.log The manual explains the config file options: man unpoller
    EOS
  end

  plist_options startup: false

  def plist
    <<~EOS
      <?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
  <dict>
      <key>Label</key>
      <string>#{plist_name}</string>
      <key>ProgramArguments</key>
      <array>
          <string>#{bin}/unpoller</string>
          <string>--config</string>
          <string>#{etc}/unpoller/up.conf</string>
      </array>
      <key>RunAtLoad</key>
      <true/>
      <key>KeepAlive</key>
      <true/>
      <key>StandardErrorPath</key>
      <string>#{var}/log/unpoller.log</string>
      <key>StandardOutPath</key>
      <string>#{var}/log/unpoller.log</string>
  </dict>
</plist>

    EOS
  end

  test do
    assert_match "unpoller v#{version}", shell_output("#{bin}/unpoller -v 2>&1", 2)
  end
end
```