### PR TITLE
switch signing keys

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v5
         with:
-          gpg_private_key: ${{ secrets.PACKAGECLOUD_SIGNING_GPG }}
+          gpg_private_key: ${{ secrets.GPG_SIGNING_KEY }}
       - name: "Setup Ruby for packagecloud uploads"
         uses: ruby/setup-ruby@v1
         with:
@@ -55,7 +55,7 @@ jobs:
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on your needs.
       - name: "make key file"
-        run: "echo '${{ secrets.PACKAGECLOUD_SIGNING_GPG }}' > /tmp/key.gpg"
+        run: "echo '${{ secrets.GPG_SIGNING_KEY }}' > /tmp/key.gpg"
       - uses: goreleaser/goreleaser-action@v3
         with:
           # either 'goreleaser' (default) or 'goreleaser-pro':
@@ -72,5 +72,5 @@ jobs:
           # This needs to be reset every year (next one at 2023-12-22) - use a fine grained PAT with Contents: R/W on golift/homebrew-mugs.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}
-          PACKAGECLOUD_SIGNING_GPG: /tmp/key.gpg
-          PACKAGECLOUD_SIGNING_KEY_ID: ${{ steps.import_gpg.outputs.keyid }}
+          GPG_SIGNING_KEY: /tmp/key.gpg
+          GPG_SIGNING_KEY_ID: ${{ steps.import_gpg.outputs.keyid }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -454,10 +454,10 @@ nfpms:
     # signing
     rpm:
       signature:
-        key_file: "{{ .Env.PACKAGECLOUD_SIGNING_GPG }}"
+        key_file: "{{ .Env.GPG_SIGNING_KEY }}"
     deb:
       signature:
-        key_file: "{{ .Env.PACKAGECLOUD_SIGNING_GPG }}"
+        key_file: "{{ .Env.GPG_SIGNING_KEY }}"
         type: origin
 
     scripts:

--- a/Makefile
+++ b/Makefile
@@ -59,14 +59,14 @@ $(shell go env GOPATH)/bin/rsrc:
 
 build-and-release: export DOCKER_REGISTRY = ghcr.io
 build-and-release: export DOCKER_IMAGE_NAME = unpoller/unpoller
-build-and-release: export PACKAGECLOUD_SIGNING_GPG = 
+build-and-release: export GPG_SIGNING_KEY = 
 
 bulid-and-release: clean
 	goreleaser release --rm-dist
 
 build: export DOCKER_REGISTRY = ghcr.io
 build: export DOCKER_IMAGE_NAME = unpoller/unpoller
-build: export PACKAGECLOUD_SIGNING_GPG = 
+build: export GPG_SIGNING_KEY = 
 
 build: clean
 	goreleaser release --rm-dist --skip-validate --skip-publish --skip-sign --debug


### PR DESCRIPTION
looks like the key isn't recognized on debs

```
[root@62c418977835 /]# rpm -K unpoller-2.7.6+git-1.aarch64.rpm
unpoller-2.7.6+git-1.aarch64.rpm: digests SIGNATURES NOT OK
```

nor rpms
```
root@a87c7b579e36:/# dpkg-sig --verify unpoller_2.7.6+git_arm64.deb
Processing unpoller_2.7.6+git_arm64.deb...
UNKNOWNSIG _gpgorigin ABC5A57C
```