### PR TITLE
Fixes rpm/deb /etc/unpoller directory permissions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -306,7 +306,7 @@ nfpms:
       - dst: /etc/unpoller
         type: dir
         file_info:
-          mode: 0740
+          mode: 0755
       - dst: /usr/share/doc/unpoller
         type: dir
         file_info:


### PR DESCRIPTION
fixes #488 by setting /etc/unpoller chmod 755