### PR TITLE
fixes client dpi strings on influx and prom

### DIFF
--- a/pkg/influxunifi/clients.go
+++ b/pkg/influxunifi/clients.go
@@ -100,10 +100,10 @@ func (u *InfluxUnifi) batchClientDPI(r report, v any, appTotal, catTotal totalsD
 				"source":      s.SourceName,
 			},
 			Fields: map[string]any{
-				"tx_packets": dpi.TxPackets,
-				"rx_packets": dpi.RxPackets,
-				"tx_bytes":   dpi.TxBytes,
-				"rx_bytes":   dpi.RxBytes,
+				"tx_packets": dpi.TxPackets.Val,
+				"rx_packets": dpi.RxPackets.Val,
+				"tx_bytes":   dpi.TxBytes.Val,
+				"rx_bytes":   dpi.RxBytes.Val,
 			},
 		})
 	}
@@ -167,10 +167,10 @@ func reportClientDPItotals(r report, appTotal, catTotal totalsDPImap) {
 							"source":      controller,
 						},
 						Fields: map[string]any{
-							"tx_packets": m.TxPackets,
-							"rx_packets": m.RxPackets,
-							"tx_bytes":   m.TxBytes,
-							"rx_bytes":   m.RxBytes,
+							"tx_packets": m.TxPackets.Val,
+							"rx_packets": m.RxPackets.Val,
+							"tx_bytes":   m.TxBytes.Val,
+							"rx_bytes":   m.RxBytes.Val,
 						},
 					}
 					newMetric.Tags[k.kind] = name

--- a/pkg/promunifi/clients.go
+++ b/pkg/promunifi/clients.go
@@ -91,10 +91,10 @@ func (u *promUnifi) exportClientDPI(r report, v any, appTotal, catTotal totalsDP
 		fillDPIMapTotals(catTotal, labelDPI[4], s.SourceName, s.SiteName, dpi)
 		// log.Println(labelDPI, dpi.Cat, dpi.App, dpi.TxBytes, dpi.RxBytes, dpi.TxPackets, dpi.RxPackets)
 		r.send([]*metric{
-			{u.Client.DPITxPackets, counter, dpi.TxPackets, labelDPI},
-			{u.Client.DPIRxPackets, counter, dpi.RxPackets, labelDPI},
-			{u.Client.DPITxBytes, counter, dpi.TxBytes, labelDPI},
-			{u.Client.DPIRxBytes, counter, dpi.RxBytes, labelDPI},
+			{u.Client.DPITxPackets, counter, dpi.TxPackets.Val, labelDPI},
+			{u.Client.DPIRxPackets, counter, dpi.RxPackets.Val, labelDPI},
+			{u.Client.DPITxBytes, counter, dpi.TxBytes.Val, labelDPI},
+			{u.Client.DPIRxBytes, counter, dpi.RxBytes.Val, labelDPI},
 		})
 	}
 }
@@ -218,10 +218,10 @@ func (u *promUnifi) exportClientDPItotals(r report, appTotal, catTotal totalsDPI
 					}
 
 					m := []*metric{
-						{u.Client.DPITxPackets, counter, m.TxPackets, labelDPI},
-						{u.Client.DPIRxPackets, counter, m.RxPackets, labelDPI},
-						{u.Client.DPITxBytes, counter, m.TxBytes, labelDPI},
-						{u.Client.DPIRxBytes, counter, m.RxBytes, labelDPI},
+						{u.Client.DPITxPackets, counter, m.TxPackets.Val, labelDPI},
+						{u.Client.DPIRxPackets, counter, m.RxPackets.Val, labelDPI},
+						{u.Client.DPITxBytes, counter, m.TxBytes.Val, labelDPI},
+						{u.Client.DPIRxBytes, counter, m.RxBytes.Val, labelDPI},
 					}
 
 					r.send(m)


### PR DESCRIPTION
Found the root cause to https://github.com/unpoller/dashboards/issues/20

This is using go representation to stringify the results. This uses the explicit value