### PR TITLE
fixes sitedpi strings on influx and prom

### DIFF
--- a/pkg/influxunifi/site.go
+++ b/pkg/influxunifi/site.go
@@ -74,10 +74,10 @@ func (u *InfluxUnifi) batchSiteDPI(r report, v any) {
 				"source":      s.SourceName,
 			},
 			Fields: map[string]any{
-				"tx_packets": dpi.TxPackets,
-				"rx_packets": dpi.RxPackets,
-				"tx_bytes":   dpi.TxBytes,
-				"rx_bytes":   dpi.RxBytes,
+				"tx_packets": dpi.TxPackets.Val,
+				"rx_packets": dpi.RxPackets.Val,
+				"tx_bytes":   dpi.TxBytes.Val,
+				"rx_bytes":   dpi.RxBytes.Val,
 			},
 		})
 	}

--- a/pkg/promunifi/site.go
+++ b/pkg/promunifi/site.go
@@ -87,10 +87,10 @@ func (u *promUnifi) exportSiteDPI(r report, v any) {
 
 		//	log.Println(labelsDPI, dpi.Cat, dpi.App, dpi.TxBytes, dpi.RxBytes, dpi.TxPackets, dpi.RxPackets)
 		r.send([]*metric{
-			{u.Site.DPITxPackets, gauge, dpi.TxPackets, labelDPI},
-			{u.Site.DPIRxPackets, gauge, dpi.RxPackets, labelDPI},
-			{u.Site.DPITxBytes, gauge, dpi.TxBytes, labelDPI},
-			{u.Site.DPIRxBytes, gauge, dpi.RxBytes, labelDPI},
+			{u.Site.DPITxPackets, gauge, dpi.TxPackets.Val, labelDPI},
+			{u.Site.DPIRxPackets, gauge, dpi.RxPackets.Val, labelDPI},
+			{u.Site.DPITxBytes, gauge, dpi.TxBytes.Val, labelDPI},
+			{u.Site.DPIRxBytes, gauge, dpi.RxBytes.Val, labelDPI},
 		})
 	}
 }


### PR DESCRIPTION
Fixes the similar issue with `clientdpi` tx/rx bytes being strings instead of floats