### PR TITLE
changed line 39 to correct path for example

### DIFF
--- a/examples/k8s_unifi_poller.yaml
+++ b/examples/k8s_unifi_poller.yaml
@@ -36,7 +36,7 @@ spec:
           protocol: UDP
         volumeMounts:
         - name: config-volume
-          mountPath: /config/unifi-poller.conf
+          mountPath: /etc/unpoller/up.conf
           subPath: unifi-poller.conf
       volumes:
       - name: config-volume


### PR DESCRIPTION
Changes to Kubernetes example. MountPath in volumeMounts inside container was wrong.