### PR TITLE
Add IP as a tag for influxdb output

### DIFF
--- a/pkg/influxunifi/clients.go
+++ b/pkg/influxunifi/clients.go
@@ -32,6 +32,7 @@ func (u *InfluxUnifi) batchClient(r report, s *unifi.Client) { // nolint: funlen
 		"use_fixedip": s.UseFixedIP.Txt,
 		"channel":     s.Channel.Txt,
 		"vlan":        s.Vlan.Txt,
+		"ip":          s.IP,
 	}
 	fields := map[string]any{
 		"anomalies":         s.Anomalies.Int64(),


### PR DESCRIPTION
Adding the IP address as a tag value for the Influxdb output matching behavior of the Prometheus output.