### PR TITLE
PDU Fix

### DIFF
--- a/pkg/datadogunifi/integration_test_expectations.yaml
+++ b/pkg/datadogunifi/integration_test_expectations.yaml
@@ -31,6 +31,55 @@ gauges:
   - unifi.clients.wired_tx_bytes
   - unifi.clients.wired_tx_bytes-r
   - unifi.clients.wired_tx_packets
+  - unifi.pdu.bytes 
+  - unifi.pdu.cpu
+  - unifi.pdu.guest_num_sta 
+  - unifi.pdu.last_seen 
+  - unifi.pdu.loadavg_1 
+  - unifi.pdu.loadavg_15 
+  - unifi.pdu.loadavg_5 
+  - unifi.pdu.mem 
+  - unifi.pdu.mem_buffer 
+  - unifi.pdu.mem_total 
+  - unifi.pdu.mem_used 
+  - unifi.pdu.memory 
+  - unifi.pdu.network 
+  - unifi.pdu.outlet_ac_power_budget 
+  - unifi.pdu.outlet_ac_power_consumption 
+  - unifi.pdu.outlet_enabled 
+  - unifi.pdu.outlet_overrides.cycle_enabled 
+  - unifi.pdu.outlet_overrides.relay_state 
+  - unifi.pdu.outlet_table.cycle_enabled 
+  - unifi.pdu.outlet_table.outlet_caps 
+  - unifi.pdu.outlet_table.outlet_current 
+  - unifi.pdu.outlet_table.outlet_power 
+  - unifi.pdu.outlet_table.outlet_power_factor 
+  - unifi.pdu.outlet_table.outlet_voltage 
+  - unifi.pdu.outlet_table.relay_state 
+  - unifi.pdu.overheating 
+  - unifi.pdu.power_source 
+  - unifi.pdu.probe 
+  - unifi.pdu.rx_bytes 
+  - unifi.pdu.stat_bytes 
+  - unifi.pdu.stat_rx_bytes 
+  - unifi.pdu.stat_rx_crypts 
+  - unifi.pdu.stat_rx_dropped 
+  - unifi.pdu.stat_rx_errors 
+  - unifi.pdu.stat_rx_frags 
+  - unifi.pdu.stat_rx_packets 
+  - unifi.pdu.stat_tx_bytes 
+  - unifi.pdu.stat_tx_dropped 
+  - unifi.pdu.stat_tx_errors 
+  - unifi.pdu.stat_tx_packets 
+  - unifi.pdu.stat_tx_retries 
+  - unifi.pdu.state 
+  - unifi.pdu.sys 
+  - unifi.pdu.system_uptime 
+  - unifi.pdu.total_max_power 
+  - unifi.pdu.tx_bytes 
+  - unifi.pdu.upgradeable 
+  - unifi.pdu.uptime 
+  - unifi.pdu.user_num_sta 
   - unifi.subsystems.drops
   - unifi.subsystems.gw_cpu
   - unifi.subsystems.gw_mem

--- a/pkg/influxunifi/integration_test_expectations.yaml
+++ b/pkg/influxunifi/integration_test_expectations.yaml
@@ -72,6 +72,96 @@ points:
       wired-tx_bytes: int
       wired-tx_bytes-r: int
       wired-tx_packets: int
+  pdu:
+    tags:
+      - mac
+      - model
+      - name
+      - serial
+      - site_name
+      - source
+      - type
+      - version
+    fields:
+      bytes: float
+      cpu: float
+      guest-num_sta: float
+      ip: string
+      last_seen: float
+      loadavg_1: float
+      loadavg_5: float
+      loadavg_15: float
+      mem: float
+      mem_buffer: float
+      mem_total: float
+      mem_used: float
+      outlet_ac_power_budget: float
+      outlet_ac_power_consumption: float
+      outlet_enabled: bool
+      overheating: bool
+      power_source: float
+      rx_bytes: float
+      stat_bytes: float
+      stat_rx_bytes: float
+      stat_rx_crypts: float
+      stat_rx_dropped: float
+      stat_rx_errors: float
+      stat_rx_frags: float
+      stat_rx_packets: float
+      stat_tx_bytes: float
+      stat_tx_dropped: float
+      stat_tx_errors: float
+      stat_tx_packets: float
+      stat_tx_retries: float
+      state: float
+      system_uptime: float
+      temp_cpu: int
+      temp_memory: int
+      temp_network: int
+      temp_probe: int
+      temp_sys: int
+      total_max_power: float
+      tx_bytes: float
+      upgradeable: bool
+      uptime: float
+      user-num_sta: float
+  pdu.outlet_overrides:
+    tags:
+      - ip
+      - mac
+      - model
+      - name
+      - outlet_index
+      - outlet_name
+      - serial
+      - site_name
+      - source
+      - type
+      - version
+    fields:
+      cycle_enabled: bool
+      relay_state: bool
+  pdu.outlet_table:
+    tags:
+      - ip
+      - mac
+      - model
+      - name
+      - outlet_index
+      - outlet_name
+      - serial
+      - site_name
+      - source
+      - type
+      - version
+    fields:
+      cycle_enabled: bool
+      outlet_caps: float
+      outlet_current: float
+      outlet_power: float
+      outlet_power_factor: float
+      outlet_voltage: float
+      relay_state: bool
   sitedpi:
     tags:
       - application
@@ -142,9 +232,9 @@ points:
       guest-num_sta: int
       ip: string
       last_seen: float
-      loadavg_15: float
       loadavg_1: float
       loadavg_5: float
+      loadavg_15: float
       mem: float
       mem_buffer: float
       mem_total: float
@@ -494,11 +584,11 @@ points:
       temp_probe: int
       temp_sys: int
       tx_bytes: float
+      upgradeable: bool
       uplink_latency: float
       uplink_name: string
       uplink_speed: float
       uplink_type: string
-      upgradeable: bool
       uptime: float
       user-num_sta: float
       version: string

--- a/pkg/inputunifi/collector.go
+++ b/pkg/inputunifi/collector.go
@@ -218,6 +218,11 @@ func extractDevices(metrics *Metrics) (*poller.Metrics, map[string]string, map[s
 		m.Devices = append(m.Devices, r)
 	}
 
+	for _, r := range metrics.Devices.PDUs {
+		devices[r.Mac] = r.Name
+		m.Devices = append(m.Devices, r)
+	}
+
 	return m, devices, bssdIDs
 }
 

--- a/pkg/promunifi/pdu.go
+++ b/pkg/promunifi/pdu.go
@@ -61,6 +61,7 @@ type pdu struct {
 }
 
 func descPDU(ns string) *pdu {
+	outlet := ns + "outlet_"
 	pns := ns + "port_"
 	sfp := pns + "sfp_"
 	labelS := []string{"site_name", "name", "source"}
@@ -68,6 +69,9 @@ func descPDU(ns string) *pdu {
 	labelF := []string{
 		"sfp_part", "sfp_vendor", "sfp_serial", "sfp_compliance",
 		"port_id", "port_num", "port_name", "port_mac", "port_ip", "site_name", "name", "source",
+	}
+	labelO := []string{
+		"outlet_description", "outlet_index", "outlet_name", "site_name", "name", "source",
 	}
 	nd := prometheus.NewDesc
 
@@ -116,6 +120,14 @@ func descPDU(ns string) *pdu {
 		SFPVoltage:     nd(sfp+"voltage", "SFP Voltage", labelF, nil),
 		// other data
 		Upgradeable: nd(ns+"upgradeable", "Upgrade-able", labelS, nil),
+		// power
+		CycleEnabled:      nd(outlet+"cycle_enabled", "Cycle Enabled", labelO, nil),
+		RelayState:        nd(outlet+"relay_state", "Relay State", labelO, nil),
+		OutletCaps:        nd(outlet+"outlet_caps", "Outlet Caps", labelO, nil),
+		OutletCurrent:     nd(outlet+"outlet_current", "Outlet Current", labelO, nil),
+		OutletPower:       nd(outlet+"outlet_power", "Outlet Power", labelO, nil),
+		OutletPowerFactor: nd(outlet+"outlet_power_factor", "Outlet Power Factor", labelO, nil),
+		OutletVoltage:     nd(outlet+"outlet_voltage", "Outlet Voltage", labelO, nil),
 	}
 }
 


### PR DESCRIPTION
While I was able to see the PDU objects being collected on the `inputunifi` side, I wasn't seeing them in the `influxunifi` output.  I traced the problem down to the PDU metrics not being added to the devices array in the `inputunifi` collector.  I am now seeing PDU statistics showing up in my Grafana/Influxdb setup.

I'm thinking since the fix was on the input side, the other output packages should also be able to pull the same data now without further modifications, but I didn't verify that was the case.