### PR TITLE
Added source interface identifier to exportUSGstats function

### DIFF
--- a/pkg/promunifi/usg.go
+++ b/pkg/promunifi/usg.go
@@ -109,17 +109,19 @@ func (u *promUnifi) exportUSG(r report, d *unifi.USG) {
 
 // Gateway Stats.
 func (u *promUnifi) exportUSGstats(r report, labels []string, gw *unifi.Gw, st unifi.SpeedtestStatus, ul unifi.Uplink) {
-	if gw == nil {
-		return
-	}
-
-	labelLan := []string{"lan", labels[1], labels[2], labels[3]}
 	var sourceInterface string
+
 	if st.SourceInterface != "" {
 		sourceInterface = st.SourceInterface
 	} else {
 		sourceInterface = "all"
 	}
+
+	if gw == nil {
+		return
+	}
+
+	labelLan := []string{"lan", labels[1], labels[2], labels[3]}
 	labelWan := []string{sourceInterface, labels[1], labels[2], labels[3]}
 
 	r.send([]*metric{

--- a/pkg/promunifi/usg.go
+++ b/pkg/promunifi/usg.go
@@ -114,7 +114,13 @@ func (u *promUnifi) exportUSGstats(r report, labels []string, gw *unifi.Gw, st u
 	}
 
 	labelLan := []string{"lan", labels[1], labels[2], labels[3]}
-	labelWan := []string{"all", labels[1], labels[2], labels[3]}
+	var sourceInterface string
+	if st.SourceInterface != "" {
+		sourceInterface = st.SourceInterface
+	} else {
+		sourceInterface = "all"
+	}
+	labelWan := []string{sourceInterface, labels[1], labels[2], labels[3]}
 
 	r.send([]*metric{
 		{u.USG.LanRxPackets, counter, gw.LanRxPackets, labelLan},


### PR DESCRIPTION
Using the Prometheus input plugin, all of the 'unpoller_device_speedtest_XYZ' metrics collected only show 'All' as the port identifier. This is an unfortunate limitation for users who have multiple WANs set. I have addressed this limitation in my environment by modifying the code in this PR and compiling unpoller from source. 


![image](https://github.com/unpoller/unpoller/assets/30290145/28bb4b5c-fdb1-4c74-bdf4-9f718528934f)
![image](https://github.com/unpoller/unpoller/assets/30290145/234b7223-4dfc-43d4-89c7-15b7449cf674)