### PR TITLE
feat: Helm chart to deploy unpoller in k8s

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,3 +83,7 @@ test:
 
 integration-test:
 	go test -timeout=30m -args=integration ./...
+
+.PHONY: helm-docs
+helm-docs:
+	go run github.com/norwoodj/helm-docs/cmd/helm-docs@latest

--- a/charts/unpoller/.helmignore
+++ b/charts/unpoller/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -6,9 +6,8 @@ version: "2.11.2"
 appVersion: "v2.11.2"
 keywords:
   - unifi
-  - home-assistant
+  - unpoller
 home: https://unpoller.com/
-icon: XXX?
 sources:
   - https://github.com/unpoller/unpoller
 

--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: unpoller
+description: A Helm chart for unpoller, a unifi prometheus exporter
+type: application
+version: "2.11.2"
+appVersion: "v2.11.2"
+keywords:
+  - esp32
+  - home-assistant
+home: https://github.com/unpoller/unpoller
+icon: XXX?
+sources:
+  - https://github.com/unpoller/unpoller
+maintainers:
+  - name: XXXX?
+    email: XXXX?
+

--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -5,13 +5,10 @@ type: application
 version: "2.11.2"
 appVersion: "v2.11.2"
 keywords:
-  - esp32
+  - unifi
   - home-assistant
-home: https://github.com/unpoller/unpoller
+home: https://unpoller.com/
 icon: XXX?
 sources:
   - https://github.com/unpoller/unpoller
-maintainers:
-  - name: XXXX?
-    email: XXXX?
 

--- a/charts/unpoller/Chart.yaml
+++ b/charts/unpoller/Chart.yaml
@@ -1,12 +1,24 @@
 apiVersion: v2
 name: unpoller
-description: A Helm chart for unpoller, a unifi prometheus exporter
+description: |
+  A Helm chart for unpoller, a unifi prometheus exporter. This chart helps deploy Unpoller (unifi metrics exporter)
+  in kubernetes clusters. 
+  It crates a Deployment to run the unpoller container, confiuration is stored in a ConfigMap and mounted in the container.
+  It supports integration with Prometheus operator, so a PodMonitor is created that will scrape the Deployment for the metrics.
+  Optionally, it can deploy automatically the dashboards into a Grafana instance through the integration with GrafanaOperator:
+  * Creates a Grafana CR with the credentials provided (or reuses existing Grafana object)
+  * Creates a Dashboard instance for all the unpoller provided charts.
+  See Readme.MD for details, and values.yaml for all the configuration options.
+  
+  See further documentation in how to install unpoller in Kubernetes in https://unpoller.com/PATH_TBD (will be updated)
 type: application
 version: "2.11.2"
 appVersion: "v2.11.2"
 keywords:
   - unifi
   - unpoller
+  - monitoring
+  - prometheus
 home: https://unpoller.com/
 sources:
   - https://github.com/unpoller/unpoller

--- a/charts/unpoller/README.md
+++ b/charts/unpoller/README.md
@@ -4,13 +4,7 @@
 
 A Helm chart for unpoller, a unifi prometheus exporter
 
-**Homepage:** <https://github.com/unpoller/unpoller>
-
-## Maintainers
-
-| Name | Email | Url |
-| ---- | ------ | --- |
-| XXXX? | <XXXX?> |  |
+**Homepage:** <https://unpoller.com/>
 
 ## Source Code
 

--- a/charts/unpoller/README.md
+++ b/charts/unpoller/README.md
@@ -1,0 +1,54 @@
+# unpoller
+
+![Version: 2.11.2](https://img.shields.io/badge/Version-2.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.11.2](https://img.shields.io/badge/AppVersion-v2.11.2-informational?style=flat-square)
+
+A Helm chart for unpoller, a unifi prometheus exporter
+
+**Homepage:** <https://github.com/unpoller/unpoller>
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| XXXX? | <XXXX?> |  |
+
+## Source Code
+
+* <https://github.com/unpoller/unpoller>
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| dashboards.create | bool | `true` |  |
+| dashboards.grafana.create | bool | `true` |  |
+| dashboards.grafana.secret.existingSecretName | string | `""` |  |
+| dashboards.grafana.secret.password | string | `"prom-operator"` |  |
+| dashboards.grafana.secret.username | string | `"prom"` |  |
+| dashboards.grafana.selectorLabels | object | `{}` |  |
+| dashboards.grafana.url | string | `""` |  |
+| fullnameOverride | string | `""` |  |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| image.repository | string | `"ghcr.io/unpoller/unpoller"` |  |
+| image.tag | string | `"v2.11.2"` |  |
+| imagePullSecrets | list | `[]` |  |
+| livenessProbe.httpGet.path | string | `"/"` |  |
+| livenessProbe.httpGet.port | string | `"http"` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podLabels | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| readinessProbe.httpGet.path | string | `"/"` |  |
+| readinessProbe.httpGet.port | string | `"http"` |  |
+| replicaCount | int | `1` |  |
+| resources | object | `{}` |  |
+| securityContext | object | `{}` |  |
+| serviceAccount.annotations | object | `{}` |  |
+| serviceAccount.automount | bool | `true` |  |
+| serviceAccount.create | bool | `true` |  |
+| serviceAccount.name | string | `""` |  |
+| tolerations | list | `[]` |  |
+| upConfig | string | `"[poller]\n    debug = false\n    quiet = false\n    plugins = []\n[prometheus]\n  disable = false\n  http_listen = \"0.0.0.0:9130\"\n  report_errors = false\n[influxdb]\n  disable = true\n[unifi]\n    dynamic = false\n[loki]\n    disable = true\n[[unifi.controller]]    \n    url         = \"https://unifi.home:8443\"\n    user        = \"unifi\"\n    pass        = \"unifi\"\n    sites       = [\"all\"]\n    save_ids    = true\n    save_dpi    = true\n    save_sites  = true\n    hash_pii    = false\n    verify_ssl  = false\n"` |  |
+

--- a/charts/unpoller/README.md
+++ b/charts/unpoller/README.md
@@ -2,7 +2,16 @@
 
 ![Version: 2.11.2](https://img.shields.io/badge/Version-2.11.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.11.2](https://img.shields.io/badge/AppVersion-v2.11.2-informational?style=flat-square)
 
-A Helm chart for unpoller, a unifi prometheus exporter
+A Helm chart for unpoller, a unifi prometheus exporter. This chart helps deploy Unpoller (unifi metrics exporter)
+in kubernetes clusters.
+It crates a Deployment to run the unpoller container, confiuration is stored in a ConfigMap and mounted in the container.
+It supports integration with Prometheus operator, so a PodMonitor is created that will scrape the Deployment for the metrics.
+Optionally, it can deploy automatically the dashboards into a Grafana instance through the integration with GrafanaOperator:
+* Creates a Grafana CR with the credentials provided (or reuses existing Grafana object)
+* Creates a Dashboard instance for all the unpoller provided charts.
+See Readme.MD for details, and values.yaml for all the configuration options.
+
+See further documentation in how to install unpoller in Kubernetes in https://unpoller.com/PATH_TBD (will be updated)
 
 **Homepage:** <https://unpoller.com/>
 

--- a/charts/unpoller/templates/_helpers.tpl
+++ b/charts/unpoller/templates/_helpers.tpl
@@ -1,0 +1,81 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "unpoller.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "unpoller.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Name for the grafana CR secret.
+*/}}
+{{- define "unpoller.grafana-secret" -}}
+{{-  printf "%s-%s"  "grafana-secret" (include "unpoller.fullname" .) | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "unpoller.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "unpoller.labels" -}}
+helm.sh/chart: {{ include "unpoller.chart" . }}
+{{ include "unpoller.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "unpoller.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "unpoller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{- define "unpoller.dashboadSelectorLabels" -}}
+{{- if .Values.dashboards.grafana.create -}}
+app.kubernetes.io/name: {{ include "unpoller.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- else -}}
+{{- with .Values.dashboards.grafana.selectorLabels }}
+{{- toYaml . }}
+{{- end }}
+{{- end -}}
+{{- end}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "unpoller.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "unpoller.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/unpoller/templates/dashboards.yaml
+++ b/charts/unpoller/templates/dashboards.yaml
@@ -9,7 +9,7 @@ spec:
   instanceSelector:
     matchLabels:
       {{- include "unpoller.dashboadSelectorLabels" . | nindent 6 }}
-  url: "https://grafana.com/api/dashboards/11314/revisions/10/download"
+  url: "https://grafana.com/api/dashboards/11314/revisions/latest/download"
   datasources:
     - inputName: "DS_PROMETHEUS"
       datasourceName: "Prometheus"
@@ -24,7 +24,7 @@ spec:
   instanceSelector:
     matchLabels:
       {{- include "unpoller.dashboadSelectorLabels" . | nindent 6 }}
-  url: "https://grafana.com/api/dashboards/11315/revisions/9/download"
+  url: "https://grafana.com/api/dashboards/11315/revisions/latest/download"
   datasources:
     - inputName: "DS_PROMETHEUS"
       datasourceName: "Prometheus"
@@ -39,7 +39,7 @@ spec:
   instanceSelector:
     matchLabels:
       {{- include "unpoller.dashboadSelectorLabels" . | nindent 6 }}
-  url: "https://grafana.com/api/dashboards/11312/revisions/9/download"
+  url: "https://grafana.com/api/dashboards/11312/revisions/latest/download"
   datasources:
     - inputName: "DS_PROMETHEUS"
       datasourceName: "Prometheus"
@@ -55,7 +55,7 @@ spec:
   instanceSelector:
     matchLabels:
       {{- include "unpoller.dashboadSelectorLabels" . | nindent 6 }}
-  url: "https://grafana.com/api/dashboards/11311/revisions/5/download"
+  url: "https://grafana.com/api/dashboards/11311/revisions/latest/download"
   datasources:
     - inputName: "DS_PROMETHEUS"
       datasourceName: "Prometheus"
@@ -71,7 +71,7 @@ spec:
   instanceSelector:
     matchLabels:
       {{- include "unpoller.dashboadSelectorLabels" . | nindent 6 }}
-  url: "https://grafana.com/api/dashboards/11313/revisions/9/download"
+  url: "https://grafana.com/api/dashboards/11313/revisions/latest/download"
   datasources:
     - inputName: "DS_PROMETHEUS"
       datasourceName: "Prometheus"

--- a/charts/unpoller/templates/dashboards.yaml
+++ b/charts/unpoller/templates/dashboards.yaml
@@ -1,0 +1,78 @@
+{{- if .Values.dashboards.create }}
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name:  unpoller-uap-insights
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+spec:
+  instanceSelector:
+    matchLabels:
+      {{- include "unpoller.dashboadSelectorLabels" . | nindent 6 }}
+  url: "https://grafana.com/api/dashboards/11314/revisions/10/download"
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "Prometheus"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: unpoller-client-insights
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+spec:
+  instanceSelector:
+    matchLabels:
+      {{- include "unpoller.dashboadSelectorLabels" . | nindent 6 }}
+  url: "https://grafana.com/api/dashboards/11315/revisions/9/download"
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "Prometheus"
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: unpoller-usw-insights
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+spec:
+  instanceSelector:
+    matchLabels:
+      {{- include "unpoller.dashboadSelectorLabels" . | nindent 6 }}
+  url: "https://grafana.com/api/dashboards/11312/revisions/9/download"
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "Prometheus"
+
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: unpoller-network-sites
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+spec:
+  instanceSelector:
+    matchLabels:
+      {{- include "unpoller.dashboadSelectorLabels" . | nindent 6 }}
+  url: "https://grafana.com/api/dashboards/11311/revisions/5/download"
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "Prometheus"
+
+---
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: unpoller-usg-insights
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+spec:
+  instanceSelector:
+    matchLabels:
+      {{- include "unpoller.dashboadSelectorLabels" . | nindent 6 }}
+  url: "https://grafana.com/api/dashboards/11313/revisions/9/download"
+  datasources:
+    - inputName: "DS_PROMETHEUS"
+      datasourceName: "Prometheus"
+{{- end }}

--- a/charts/unpoller/templates/deployment.yaml
+++ b/charts/unpoller/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "unpoller.fullname" . }}
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "unpoller.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "unpoller.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "unpoller.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 9130
+              name: tcp
+              protocol: TCP
+            - containerPort: 9130
+              name: udp
+              protocol: UDP
+          livenessProbe:
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
+          readinessProbe:
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config-volume
+              mountPath: /etc/unpoller/up.conf
+              subPath: up.conf
+      volumes:
+        - name: config-volume
+          secret:
+            secretName: unifi-poller
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/unpoller/templates/grafana-secret.yaml
+++ b/charts/unpoller/templates/grafana-secret.yaml
@@ -1,0 +1,11 @@
+{{- if and .Values.dashboards.grafana.create (not .Values.dashboards.grafana.secret.existingSecretName)}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "unpoller.grafana-secret" . }}
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+stringData:
+  GF_SECURITY_ADMIN_PASSWORD: {{ .Values.dashboards.grafana.secret.password  }}
+  GF_SECURITY_ADMIN_USER: {{ .Values.dashboards.grafana.secret.username  }}
+{{- end }}

--- a/charts/unpoller/templates/grafana.yaml
+++ b/charts/unpoller/templates/grafana.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.dashboards.grafana.create }}
+apiVersion: grafana.integreatly.org/v1beta1
+kind: Grafana
+metadata:
+  name:  {{ include "unpoller.fullname" . }}
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+spec:
+  external:
+    url: http://monitoring-promstack-grafana #Grafana URL
+    adminPassword:
+      name: grafana-admin-credentials
+      key: GF_SECURITY_ADMIN_PASSWORD
+    adminUser:
+      name: grafana-admin-credentials
+      key: GF_SECURITY_ADMIN_USER
+{{- end }}

--- a/charts/unpoller/templates/pod-monitor.yaml
+++ b/charts/unpoller/templates/pod-monitor.yaml
@@ -1,0 +1,12 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: unifi-poller
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "unpoller.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: tcp

--- a/charts/unpoller/templates/serviceaccount.yaml
+++ b/charts/unpoller/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "unpoller.serviceAccountName" . }}
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/charts/unpoller/templates/unpoller-config-secret.yaml
+++ b/charts/unpoller/templates/unpoller-config-secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "unpoller.fullname" . }}
+  labels:
+    {{- include "unpoller.labels" . | nindent 4 }}
+stringData:
+  up.conf: |
+    {{- .Values.upConfig | nindent 4}}

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -84,7 +84,7 @@ dashboards:
       # it must contain two keys: GF_SECURITY_ADMIN_PASSWORD and GF_SECURITY_ADMIN_USER.
       existingSecretName: ""
       # When existingSecretName is not provided, username and password must be provided. A new secret will be
-      # created with the provided username and password. GF_SECURITY_ADMIN_USER
+      # created with the provided username and password. GF_SECURITY_ADMIN_USER.
       username: "prom"
       # Password for username, will create field GF_SECURITY_ADMIN_PASSWORD
       password: "prom-operator"

--- a/charts/unpoller/values.yaml
+++ b/charts/unpoller/values.yaml
@@ -1,0 +1,118 @@
+# Default values for unpoller.
+
+replicaCount: 1
+
+image:
+  repository:  "ghcr.io/unpoller/unpoller"
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: "v2.11.2"
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+livenessProbe:
+  httpGet:
+    path: /
+    port: http
+readinessProbe:
+  httpGet:
+    path: /
+    port: http
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+# section to configure he unpoller dashboards, relaying on the CRDs from grafana operator. https://github.com/grafana/grafana-operator
+dashboards:
+  create: true
+  # Configures the Grafana instance (grafana.integreatly.org/v1beta1)
+  grafana:
+    # Whether the Grafana instance should be created, charts still can be created and
+    # use the selectorLabels to install the charts in an already existing Grafana.
+    create: true
+    # the set of labels to be matched against the existing Grafana CRD, must be provided when create is false.
+    selectorLabels: {}
+    # Url for the grafana instance, used as .spec.external.url in the Grafana instance
+    url: ""
+    # Configuration for the username/password of grafana
+    secret:
+      # if the secret is externally provisioned, you can reference the name here.
+      # it must contain two keys: GF_SECURITY_ADMIN_PASSWORD and GF_SECURITY_ADMIN_USER.
+      existingSecretName: ""
+      # When existingSecretName is not provided, username and password must be provided. A new secret will be
+      # created with the provided username and password. GF_SECURITY_ADMIN_USER
+      username: "prom"
+      # Password for username, will create field GF_SECURITY_ADMIN_PASSWORD
+      password: "prom-operator"
+
+# Configuration file to be loaded by unpoller, See Github example page for more details.
+# https://github.com/unpoller/unpoller/blob/master/examples/up.conf.example
+upConfig: |
+  [poller]
+      debug = false
+      quiet = false
+      plugins = []
+  [prometheus]
+    disable = false
+    http_listen = "0.0.0.0:9130"
+    report_errors = false
+  [influxdb]
+    disable = true
+  [unifi]
+      dynamic = false
+  [loki]
+      disable = true
+  [[unifi.controller]]    
+      url         = "https://unifi.home:8443"
+      user        = "unifi"
+      pass        = "unifi"
+      sites       = ["all"]
+      save_ids    = true
+      save_dpi    = true
+      save_sites  = true
+      hash_pii    = false
+      verify_ssl  = false


### PR DESCRIPTION
Initial version of a helm chart to deploy unpoller in kubernetes.

* Deployment for unpoller
* Secret for the unpoller configuration
* PodMonitor for unpoller deployment (Depends on PrometheusOperator)
* Optional Dashboards that import dashboards from https://grafana.com/grafana/dashboards/ in prometheus mode
* Optional Grafana Instance to persist the Dashboards
* Makefile target that generates Helm documentation.

One this PR is ready, two more PRs needs to be created:
* CI to publish the dashboards (there are multiple ways to skin the cat, and depends on where the maintainers of the repo want to keep the artifacts, GH branch (usual approach for small projects) GH packages, external OCI storage).
* Update the documentation in how to deploy Unpoller in k8s).

cc: @platinummonkey 
