### PR TITLE
Trigger helm release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,3 +83,12 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: golift/unifi-poller
+      - name: Trigger unpoller version update in helm-chart-update
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/unpoller/helm-chart/actions/workflows/OnUnpollerRelease/dispatches \
+          -d '{"ref":"main","inputs":{"unpoller_version":"${{github.ref_name}}" }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           repository: golift/unifi-poller
+
       - name: Trigger unpoller version update in helm-chart-update
         run: |
           curl -L \


### PR DESCRIPTION
This is the companion PR for https://github.com/unpoller/helm-chart/pull/1/files 
When the new version of unpoller is released, we trigger the workflow in the chart, so the versions are kept in lock-step.

@SuperQ @platinummonkey 

I triggered the release process manually and everything seems to be working. I think I need to do a final PR to glue everything together, I don't think helm will like tags starting with **v** in the verions v2.xxx
