### PR TITLE
Add support for default_site_name_override to customize default site names

### DIFF
--- a/examples/up.conf.example
+++ b/examples/up.conf.example
@@ -152,6 +152,9 @@
   # A setting of ["all"] will poll all sites; this works if you only have 1 site too.
   sites = ["all"]
 
+  # Added an example for overriding the default site name.
+  # default_site_name_override = "My Custom Default Site"
+
   # Specify a timeout, leave missing to declare infinite wait. This determines the maximum
   # time to wait for a response from the unifi controller on any API request.
   # timeout = 60s

--- a/examples/up.json.example
+++ b/examples/up.json.example
@@ -42,7 +42,7 @@
     "tags": [
       "customer:abcde"
     ]
-  }
+  },
 
   "unifi": {
     "dynamic": false,
@@ -59,7 +59,8 @@
       "save_dpi":    false,
       "save_sites":  true,
       "hash_pii":    false,
-      "verify_ssl":  false
+      "verify_ssl":  false,
+      "default_site_name_override": "My Custom Default Site"
     },
     "controllers": [
       {

--- a/examples/up.yaml.example
+++ b/examples/up.yaml.example
@@ -60,7 +60,8 @@ unifi:
     save_sites:  true
     hash_pii:    false
     verify_ssl:  false
-
+    # Added an example for overriding the default site name.
+    # default_site_name_override: "My Custom Default Site"
 
   controllers:
    # Repeat the following stanza to poll multiple controllers.

--- a/pkg/inputunifi/collector.go
+++ b/pkg/inputunifi/collector.go
@@ -278,7 +278,16 @@ func (u *InputUnifi) getFilteredSites(c *Controller) ([]*unifi.Site, error) {
 	sites, err := c.Unifi.GetSites()
 	if err != nil {
 		return nil, fmt.Errorf("controller: %w", err)
-	} else if len(c.Sites) == 0 || StringInSlice("all", c.Sites) {
+	}
+
+	// Apply the default_site_name_override if the site is marked as default.
+	for _, site := range sites {
+		if site.IsDefaultSite && c.DefaultSiteNameOverride != "" {
+			site.Name = c.DefaultSiteNameOverride
+		}
+	}
+
+	if len(c.Sites) == 0 || StringInSlice("all", c.Sites) {
 		return sites, nil
 	}
 

--- a/pkg/inputunifi/collector.go
+++ b/pkg/inputunifi/collector.go
@@ -280,11 +280,9 @@ func (u *InputUnifi) getFilteredSites(c *Controller) ([]*unifi.Site, error) {
 		return nil, fmt.Errorf("controller: %w", err)
 	}
 
-	// Apply the default_site_name_override if the site is marked as default.
-	for _, site := range sites {
-		if site.IsDefaultSite && c.DefaultSiteNameOverride != "" {
-			site.Name = c.DefaultSiteNameOverride
-		}
+	// Apply the default_site_name_override to the first site in the list, if configured.
+	if len(sites) > 0 && c.DefaultSiteNameOverride != "" {
+		sites[0].Name = c.DefaultSiteNameOverride
 	}
 
 	if len(c.Sites) == 0 || StringInSlice("all", c.Sites) {

--- a/pkg/inputunifi/input.go
+++ b/pkg/inputunifi/input.go
@@ -34,24 +34,25 @@ type InputUnifi struct {
 // Controller represents the configuration for a UniFi Controller.
 // Each polled controller may have its own configuration.
 type Controller struct {
-	VerifySSL  *bool        `json:"verify_ssl"     toml:"verify_ssl"     xml:"verify_ssl"     yaml:"verify_ssl"`
-	SaveAnomal *bool        `json:"save_anomalies" toml:"save_anomalies" xml:"save_anomalies" yaml:"save_anomalies"`
-	SaveAlarms *bool        `json:"save_alarms"    toml:"save_alarms"    xml:"save_alarms"    yaml:"save_alarms"`
-	SaveEvents *bool        `json:"save_events"    toml:"save_events"    xml:"save_events"    yaml:"save_events"`
-	SaveIDs    *bool        `json:"save_ids"       toml:"save_ids"       xml:"save_ids"       yaml:"save_ids"`
-	SaveDPI    *bool        `json:"save_dpi"       toml:"save_dpi"       xml:"save_dpi"       yaml:"save_dpi"`
-	SaveRogue  *bool        `json:"save_rogue"     toml:"save_rogue"     xml:"save_rogue"     yaml:"save_rogue"`
-	HashPII    *bool        `json:"hash_pii"       toml:"hash_pii"       xml:"hash_pii"       yaml:"hash_pii"`
-	DropPII    *bool        `json:"drop_pii"       toml:"drop_pii"       xml:"drop_pii"       yaml:"drop_pii"`
-	SaveSites  *bool        `json:"save_sites"     toml:"save_sites"     xml:"save_sites"     yaml:"save_sites"`
-	CertPaths  []string     `json:"ssl_cert_paths" toml:"ssl_cert_paths" xml:"ssl_cert_path"  yaml:"ssl_cert_paths"`
-	User       string       `json:"user"           toml:"user"           xml:"user"           yaml:"user"`
-	Pass       string       `json:"pass"           toml:"pass"           xml:"pass"           yaml:"pass"`
-	APIKey     string       `json:"api_key"        toml:"api_key"        xml:"api_key"        yaml:"api_key"`
-	URL        string       `json:"url"            toml:"url"            xml:"url"            yaml:"url"`
-	Sites      []string     `json:"sites"          toml:"sites"          xml:"site"           yaml:"sites"`
-	Unifi      *unifi.Unifi `json:"-"              toml:"-"              xml:"-"              yaml:"-"`
-	ID         string       `json:"id,omitempty"` // this is an output, not an input.
+	VerifySSL              *bool        `json:"verify_ssl"     toml:"verify_ssl"     xml:"verify_ssl"     yaml:"verify_ssl"`
+	SaveAnomal             *bool        `json:"save_anomalies" toml:"save_anomalies" xml:"save_anomalies" yaml:"save_anomalies"`
+	SaveAlarms             *bool        `json:"save_alarms"    toml:"save_alarms"    xml:"save_alarms"    yaml:"save_alarms"`
+	SaveEvents             *bool        `json:"save_events"    toml:"save_events"    xml:"save_events"    yaml:"save_events"`
+	SaveIDs                *bool        `json:"save_ids"       toml:"save_ids"       xml:"save_ids"       yaml:"save_ids"`
+	SaveDPI                *bool        `json:"save_dpi"       toml:"save_dpi"       xml:"save_dpi"       yaml:"save_dpi"`
+	SaveRogue              *bool        `json:"save_rogue"     toml:"save_rogue"     xml:"save_rogue"     yaml:"save_rogue"`
+	HashPII                *bool        `json:"hash_pii"       toml:"hash_pii"       xml:"hash_pii"       yaml:"hash_pii"`
+	DropPII                *bool        `json:"drop_pii"       toml:"drop_pii"       xml:"drop_pii"       yaml:"drop_pii"`
+	SaveSites              *bool        `json:"save_sites"     toml:"save_sites"     xml:"save_sites"     yaml:"save_sites"`
+	CertPaths              []string     `json:"ssl_cert_paths" toml:"ssl_cert_paths" xml:"ssl_cert_path"  yaml:"ssl_cert_paths"`
+	User                   string       `json:"user"           toml:"user"           xml:"user"           yaml:"user"`
+	Pass                   string       `json:"pass"           toml:"pass"           xml:"pass"           yaml:"pass"`
+	APIKey                 string       `json:"api_key"        toml:"api_key"        xml:"api_key"        yaml:"api_key"`
+	URL                    string       `json:"url"            toml:"url"            xml:"url"            yaml:"url"`
+	Sites                  []string     `json:"sites"          toml:"sites"          xml:"site"           yaml:"sites"`
+	DefaultSiteNameOverride string       `json:"default_site_name_override" toml:"default_site_name_override" xml:"default_site_name_override" yaml:"default_site_name_override"`
+	Unifi                  *unifi.Unifi `json:"-"              toml:"-"              xml:"-"              yaml:"-"`
+	ID                     string       `json:"id,omitempty"` // this is an output, not an input.
 }
 
 // Config contains our configuration data.
@@ -356,6 +357,11 @@ func (u *InputUnifi) setControllerDefaults(c *Controller) *Controller { //nolint
 
 	if len(c.Sites) == 0 {
 		c.Sites = u.Default.Sites
+	}
+
+	// Added handling for the new default_site_name_override parameter.
+	if c.DefaultSiteNameOverride == "" {
+		c.DefaultSiteNameOverride = u.Default.DefaultSiteNameOverride
 	}
 
 	return c


### PR DESCRIPTION
This PR adds a new `default_site_name_override` configuration parameter, allowing users to specify a custom site name for the **default site** (i.e., the **first site** on a controller).

This feature is useful for UDM devices where the default site's description cannot always be changed, or where site names may vary depending on the system language (e.g., "Default (default)", "Défaut (default)", etc.).
By setting a custom name, users can maintain clearer and more consistent metrics tagging.

**Notes**:

- The override only applies to the default site.
- If the `default_site_name_override` parameter is not set, the existing behavior remains unchanged.
- The new parameter is available both via configuration files and environment variables, following the current Unpoller configuration approach.

I have tried to follow the existing coding style and conventions, but I recommend reviewing the code to ensure it fully aligns with your coding standards and practices.