### PR TITLE
fix: skip loki reporting if streams is empty

### DIFF
--- a/pkg/lokiunifi/loki.go
+++ b/pkg/lokiunifi/loki.go
@@ -180,6 +180,11 @@ func (l *Loki) ProcessEvents(report *Report, events *poller.Events) error {
 	}
 
 	logs := report.ProcessEventLogs(events)
+	if len(logs.Streams) == 0 {
+		l.LogDebugf("No new events to send to Loki.")
+		return nil
+	}
+
 	if err := l.client.Post(logs); err != nil {
 		return fmt.Errorf("sending to Loki failed: %w", err)
 	}


### PR DESCRIPTION
It seems like loki is not accepting empty steams anymore since [this commit](https://github.com/grafana/loki/commit/17bf32bc50598aaf620fda269511c6db64359dbd) and returns 422 error.

This PR adds a length check and prevents sending empty streams to loki so the error log stays clean.

Addresses #843 