### PR TITLE
Add Docker health check support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,7 @@ FROM gcr.io/distroless/static-debian11
 COPY unpoller /usr/bin/unpoller
 COPY --from=builder /etc/unpoller /etc/unpoller
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+  CMD ["/usr/bin/unpoller", "--health"]
+
 ENTRYPOINT [ "/usr/bin/unpoller" ]

--- a/examples/MANUAL.md
+++ b/examples/MANUAL.md
@@ -24,7 +24,7 @@ examples and default configurations.
 
 OPTIONS
 ---
-`unpoller [-c <config-file>,[config-file]] [-j <filter>] [-e <pass>] [-h] [-v]`
+`unpoller [-c <config-file>,[config-file]] [-j <filter>] [-e <pass>] [--health] [-d] [-h] [-v]`
 
     -c, --config <config-file>,[config-file]
         Provide a configuration file (instead of the default). You may provide
@@ -38,6 +38,17 @@ OPTIONS
 
     -v, --version
         Display version and exit.
+
+    --health
+        Run a health check and exit with status 0 (healthy) or 1 (unhealthy).
+        This validates the configuration file, ensures input and output plugins
+        are properly configured, and performs basic connectivity checks. Useful
+        for Docker HEALTHCHECK and container orchestration readiness probes.
+
+    -d, --debugio
+        Debug the inputs and outputs configured and exit. This performs more
+        verbose validation checks than --health and is useful for troubleshooting
+        configuration issues.
 
     -j, --dumpjson <filter>
         This is a debug option; use this when you are missing data in your graphs,

--- a/init/docker/README.md
+++ b/init/docker/README.md
@@ -9,3 +9,18 @@ in InfluxDB by UniFi Poller.
 ##### HOWTO
 **Learn more about how and when to use these *Docker Compose* files in the
 [Docker Wiki](https://unpoller.com/docs/install/dockercompose).**
+
+## Health Check
+
+The UniFi Poller Docker image includes a built-in health check that validates
+the configuration and checks plugin connectivity. The health check runs every
+30 seconds and marks the container as unhealthy if configuration issues are
+detected or if enabled outputs cannot be reached.
+
+You can manually run the health check:
+```bash
+docker exec <container_name> /usr/bin/unpoller --health
+```
+
+The health check is automatically used by Docker and container orchestration
+platforms (Kubernetes, Docker Swarm, etc.) to determine container health status.

--- a/init/docker/docker-compose.yml
+++ b/init/docker/docker-compose.yml
@@ -34,6 +34,8 @@ services:
   unifi-poller:
     restart: always
     image: ghcr.io/unpoller/unpoller:${POLLER_TAG}
+    # Health check is built into the Docker image
+    # It validates configuration and checks plugin connectivity
     depends_on:
       - grafana
       - influxdb

--- a/init/synology-docker-compose/docker-compose.yml
+++ b/init/synology-docker-compose/docker-compose.yml
@@ -36,6 +36,8 @@ services:
   unifi-poller:
     restart: always
     image: ghcr.io/unpoller/unpoller:${POLLER_TAG}
+    # Health check is built into the Docker image
+    # It validates configuration and checks plugin connectivity
     environment:
       - UP_INFLUXDB_USER=${INFLUXDB_ADMIN_USER}
       - UP_INFLUXDB_PASS=${INFLUXDB_ADMIN_PASSWORD}

--- a/pkg/poller/config.go
+++ b/pkg/poller/config.go
@@ -73,6 +73,7 @@ type Flags struct {
 	HashPW     string
 	ShowVer    bool
 	DebugIO    bool
+	Health     bool
 	*pflag.FlagSet
 }
 

--- a/pkg/poller/start.go
+++ b/pkg/poller/start.go
@@ -34,6 +34,10 @@ func (u *UnifiPoller) Start() error {
 		return u.PrintPasswordHash()
 	}
 
+	if u.Flags.Health {
+		return u.HealthCheck()
+	}
+
 	cfile, err := getFirstFile(strings.Split(u.Flags.ConfigFile, ","))
 	if err != nil {
 		return err
@@ -76,6 +80,7 @@ func (f *Flags) Parse(args []string) {
 	f.StringVarP(&f.DumpJSON, "dumpjson", "j", "",
 		"This debug option prints a json payload and exits. See man page for more info.")
 	f.BoolVarP(&f.DebugIO, "debugio", "d", false, "Debug the Inputs and Outputs configured and exit.")
+	f.BoolVarP(&f.Health, "health", "", false, "Run health check and exit with status 0 (healthy) or 1 (unhealthy).")
 	f.StringVarP(&f.ConfigFile, "config", "c", DefaultConfFile(),
 		"Poller config file path. Separating multiple paths with a comma will load the first config file found.")
 	f.BoolVarP(&f.ShowVer, "version", "v", false, "Print the version and exit.")


### PR DESCRIPTION
Implements #406 by adding a --health CLI flag and HEALTHCHECK instruction to the Dockerfile. This allows Docker and container orchestration platforms to monitor container health automatically.

Changes:
- Added --health flag that validates configuration and plugin connectivity
- Implemented HealthCheck() method in pkg/poller/commands.go
- Updated Dockerfile with HEALTHCHECK instruction (30s interval, 10s timeout)
- Updated MANUAL.md with --health flag documentation
- Added health check documentation to Docker README
- Added comments to docker-compose examples about built-in health check

The health check:
- Validates configuration file is found and parseable
- Ensures at least one input and one enabled output are configured
- Performs basic validation on enabled outputs
- Returns exit code 0 (healthy) or 1 (unhealthy)
- Runs silently for Docker compatibility