### PR TITLE
Add byte counters for InfluxDB and Prometheus outputs (issue #350)

### DIFF
--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -87,6 +87,7 @@ type Report struct {
 	Total   int             // Total count of metrics recorded.
 	Errors  int             // Total count of errors recording metrics.
 	Zeros   int             // Total count of metrics equal to zero.
+	Bytes   int             // Total count of bytes written.
 	USG     int             // Total count of USG devices.
 	USW     int             // Total count of USW devices.
 	PDU     int             // Total count of PDU devices.


### PR DESCRIPTION
Track the number of bytes written per request for both InfluxDB and Prometheus outputs.

InfluxDB:
- Added bytesT counter constant
- Implemented calculateMetricBytes() to estimate line protocol size
- Updated batchV1() and batchV2() to count bytes per point
- Updated log output to display bytes written

Prometheus:
- Added Bytes field to Report struct
- Updated export() to calculate approximate metric byte size
- Updated log output to display bytes written
