### PR TITLE
Add configuration option to suppress unknown device type messages

### DIFF
--- a/examples/remote_api_example.conf
+++ b/examples/remote_api_example.conf
@@ -7,6 +7,10 @@
 [poller]
 debug = false
 quiet = false
+# log_unknown_types = false   # Set to true to log unknown device types as DEBUG messages.
+                              # By default, newer UniFi device types that aren't recognized
+                              # are silently ignored to reduce log volume. Enable this when
+                              # debugging or reporting new device types to developers.
 
 [unifi]
 remote = true

--- a/examples/remote_api_example.yaml
+++ b/examples/remote_api_example.yaml
@@ -7,6 +7,10 @@
 poller:
   debug: false
   quiet: false
+  # log_unknown_types: false   # Set to true to log unknown device types as DEBUG messages.
+                               # By default, newer UniFi device types that aren't recognized
+                               # are silently ignored to reduce log volume. Enable this when
+                               # debugging or reporting new device types to developers.
 
 unifi:
   # Enable remote API mode - automatically discovers all consoles

--- a/examples/up.conf.example
+++ b/examples/up.conf.example
@@ -11,6 +11,11 @@
   # Recommend enabling debug with this setting for better error logging.
   quiet = false
 
+  # Log unknown device types as DEBUG messages. By default (false), newer UniFi
+  # device types that aren't recognized are silently ignored to reduce log volume.
+  # Enable this when debugging or reporting new device types to developers.
+  # log_unknown_types = false
+
   # Load dynamic plugins. Advanced use; only sample mysql plugin provided by default.
   plugins = []
 

--- a/examples/up.json.example
+++ b/examples/up.json.example
@@ -2,7 +2,8 @@
   "poller": {
     "debug":   false,
     "quiet":   false,
-    "plugins": []
+    "plugins": [],
+    "log_unknown_types": false
   },
 
   "prometheus": {

--- a/examples/up.yaml.example
+++ b/examples/up.yaml.example
@@ -9,6 +9,10 @@ poller:
   debug: false
   quiet: false
   plugins: []
+  # log_unknown_types: false   # Set to true to log unknown device types as DEBUG messages.
+                               # By default, newer UniFi device types that aren't recognized
+                               # are silently ignored to reduce log volume. Enable this when
+                               # debugging or reporting new device types to developers.
 
 prometheus:
   disable:       false

--- a/pkg/influxunifi/influxdb.go
+++ b/pkg/influxunifi/influxdb.go
@@ -467,6 +467,8 @@ func (u *InfluxUnifi) switchExport(r report, v any) { //nolint:cyclop
 	case *unifi.SpeedTestResult:
 		u.batchSpeedTest(r, v)
 	default:
-		u.LogErrorf("invalid export type: %T", v)
+		if u.Collector.Poller().LogUnknownTypes {
+			u.LogDebugf("unknown export type: %T", v)
+		}
 	}
 }

--- a/pkg/poller/config.go
+++ b/pkg/poller/config.go
@@ -102,9 +102,10 @@ type Config struct {
 
 // Poller is the global config values.
 type Poller struct {
-	Plugins []string `json:"plugins" toml:"plugins" xml:"plugin"     yaml:"plugins"`
-	Debug   bool     `json:"debug"   toml:"debug"   xml:"debug,attr" yaml:"debug"`
-	Quiet   bool     `json:"quiet"   toml:"quiet"   xml:"quiet,attr" yaml:"quiet"`
+	Plugins         []string `json:"plugins"           toml:"plugins"           xml:"plugin"               yaml:"plugins"`
+	Debug           bool     `json:"debug"             toml:"debug"             xml:"debug,attr"           yaml:"debug"`
+	Quiet           bool     `json:"quiet"             toml:"quiet"             xml:"quiet,attr"           yaml:"quiet"`
+	LogUnknownTypes bool     `json:"log_unknown_types" toml:"log_unknown_types" xml:"log_unknown_types"    yaml:"log_unknown_types"`
 }
 
 // LoadPlugins reads-in dynamic shared libraries.

--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -452,6 +452,8 @@ func (u *promUnifi) switchExport(r report, v any) {
 	case *unifi.UsageByCountry:
 		u.exportCountryTraffic(r, v)
 	default:
-		u.LogErrorf("invalid type: %T", v)
+		if u.Collector.Poller().LogUnknownTypes {
+			u.LogDebugf("unknown type: %T", v)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
Fixes #912 

Adds a new configuration option `log_unknown_types` to control logging of unknown UniFi device types. By default (false), unknown device types are silently ignored to reduce log volume. When enabled, they are logged as DEBUG messages instead of ERROR.

## Problem
UniFi Poller generates ERROR messages for newer UniFi device types it doesn't recognize, creating significant log volume (several KB per message) that impacts logging infrastructure performance (loki, alloy, etc). These messages are not actionable by users/operators since they simply indicate the device type isn't yet supported by UnPoller.

## Solution
- Added `log_unknown_types` boolean config option to the `poller` section (defaults to false)
- Modified `pkg/influxunifi/influxdb.go` to conditionally log unknown device types as DEBUG instead of ERROR
- Modified `pkg/promunifi/collector.go` to conditionally log unknown device types as DEBUG instead of ERROR
- Updated all example configuration files with clear documentation

## Changes
- `pkg/poller/config.go`: Added `LogUnknownTypes` field
- `pkg/influxunifi/influxdb.go`: Changed from `LogErrorf` to conditional `LogDebugf`
- `pkg/promunifi/collector.go`: Changed from `LogErrorf` to conditional `LogDebugf`
- `examples/*.example`: Added documentation for the new option

## Usage
**Config file (TOML):**
```toml
[poller]
  log_unknown_types = false  # Default: suppress unknown device type messages
```

**Config file (YAML):**
```yaml
poller:
  log_unknown_types: false  # Default: suppress unknown device type messages
```

**Environment Variable:**
```bash
UP_POLLER_LOG_UNKNOWN_TYPES=true  # Enable logging of unknown types
```

## Benefits
1. **Reduces log volume** - Unknown device types are silently ignored by default
2. **Proper log level** - Changed from ERROR to DEBUG (accurately reflects non-actionable info)
3. **Maintains visibility** - Can be enabled for debugging/reporting new device types
4. **Backward compatible** - Existing configs will automatically suppress these messages

## Test plan
- [x] Code compiles successfully
- [x] Existing tests pass
- [x] JSON configuration is valid
- [x] Default behavior suppresses unknown device type messages
- [x] When enabled with debug mode, messages appear as DEBUG level

🤖 Generated with [Claude Code](https://claude.com/claude-code)