### PR TITLE
Allow PoE-providing ports to be scraped even when disabled

### DIFF
--- a/pkg/datadogunifi/usw.go
+++ b/pkg/datadogunifi/usw.go
@@ -79,8 +79,8 @@ func (u *DatadogUnifi) batchUSWstat(sw *unifi.Sw) map[string]float64 {
 //nolint:funlen
 func (u *DatadogUnifi) batchPortTable(r report, t map[string]string, pt []unifi.Port) {
 	for _, p := range pt {
-		if !u.DeadPorts && (!p.Up.Val || !p.Enable.Val) {
-			continue // only record UP ports.
+		if !u.DeadPorts && (!p.Up.Val || !p.Enable.Val) && p.PoePower.Val == 0 {
+			continue // only record UP ports, or ports providing PoE power.
 		}
 
 		tags := cleanTags(map[string]string{

--- a/pkg/influxunifi/usw.go
+++ b/pkg/influxunifi/usw.go
@@ -75,8 +75,8 @@ func (u *InfluxUnifi) batchUSWstat(sw *unifi.Sw) map[string]any {
 //nolint:funlen
 func (u *InfluxUnifi) batchPortTable(r report, t map[string]string, pt []unifi.Port) {
 	for _, p := range pt {
-		if !u.DeadPorts && (!p.Up.Val || !p.Enable.Val) {
-			continue // only record UP ports.
+		if !u.DeadPorts && (!p.Up.Val || !p.Enable.Val) && p.PoePower.Val == 0 {
+			continue // only record UP ports, or ports providing PoE power.
 		}
 
 		tags := map[string]string{

--- a/pkg/promunifi/pdu.go
+++ b/pkg/promunifi/pdu.go
@@ -197,8 +197,8 @@ func (u *promUnifi) exportPDUstats(r report, labels []string, sw *unifi.Sw) {
 func (u *promUnifi) exportPDUPrtTable(r report, labels []string, pt []unifi.Port) {
 	// Per-port data on a switch
 	for _, p := range pt {
-		if !u.DeadPorts && (!p.Up.Val || !p.Enable.Val) {
-			continue
+		if !u.DeadPorts && (!p.Up.Val || !p.Enable.Val) && p.PoePower.Val == 0 {
+			continue // skip dead ports unless they're providing PoE power
 		}
 
 		// Copy labels, and add four new ones.

--- a/pkg/promunifi/usw.go
+++ b/pkg/promunifi/usw.go
@@ -176,8 +176,8 @@ func (u *promUnifi) exportUSWstats(r report, labels []string, sw *unifi.Sw) {
 func (u *promUnifi) exportPRTtable(r report, labels []string, pt []unifi.Port) {
 	// Per-port data on a switch
 	for _, p := range pt {
-		if !u.DeadPorts && (!p.Up.Val || !p.Enable.Val) {
-			continue
+		if !u.DeadPorts && (!p.Up.Val || !p.Enable.Val) && p.PoePower.Val == 0 {
+			continue // skip dead ports unless they're providing PoE power
 		}
 
 		// Copy labels, and add four new ones.


### PR DESCRIPTION
## Summary
Fixes #910 

Allows ports providing PoE power to be scraped even when they are disabled or down. This is useful for users who have ports disabled for security reasons but still want to monitor PoE power consumption.

## Problem
Currently, when `dead_ports` is set to `false` (the default), ports that are disabled or down are completely skipped from metrics collection. This means users cannot collect PoE metrics from ports that are:
- Disabled for security reasons
- Providing power but not network connectivity
- Down but still supplying PoE power

For example, a port might be configured as "Disabled" in UniFi for security while still providing power to a PoE device.

## Solution
Modified the "dead port" check in all output plugins to exclude ports from being skipped if they are providing non-zero PoE power, even if they are disabled or down.

**Previous logic:**
```go
if !u.DeadPorts && (!p.Up.Val || !p.Enable.Val) {
    continue // skip the port
}
```

**New logic:**
```go
if !u.DeadPorts && (!p.Up.Val || !p.Enable.Val) && p.PoePower.Val == 0 {
    continue // skip the port unless it's providing PoE power
}
```

## Changes
- `pkg/influxunifi/usw.go`: Updated port filtering logic
- `pkg/promunifi/usw.go`: Updated port filtering logic
- `pkg/promunifi/pdu.go`: Updated port filtering logic
- `pkg/datadogunifi/usw.go`: Updated port filtering logic

## Behavior
With this change:
- **Default behavior (`dead_ports: false`)**: Ports that are down/disabled AND not providing PoE power are skipped
- **Disabled ports providing PoE power**: Are now included in metrics collection
- **With `dead_ports: true`**: All ports are collected (no change in behavior)

## Benefits
1. **Allows PoE monitoring on disabled ports** - Users can monitor power consumption even when ports are disabled for security
2. **More accurate PoE metrics** - Captures all PoE power usage regardless of port state
3. **Backward compatible** - Existing behavior is preserved for ports not providing PoE power
4. **Consistent across all outputs** - InfluxDB, Prometheus, Datadog all behave the same way

## Test plan
- [x] Code compiles successfully
- [x] Existing tests pass
- [x] Logic correctly identifies ports providing PoE power
- [x] Ports with zero PoE power are still filtered when disabled/down
- [x] Behavior consistent across all output plugins

🤖 Generated with [Claude Code](https://claude.com/claude-code)