### PR TITLE
Populate num_user field for VPN subsystem metrics

### DIFF
--- a/pkg/datadogunifi/site.go
+++ b/pkg/datadogunifi/site.go
@@ -22,8 +22,14 @@ func (u *DatadogUnifi) reportSite(r report, s *unifi.Site) {
 			tag("lan_ip", h.LanIP),
 		}
 
+		// For VPN subsystem, use RemoteUserNumActive for num_user if NumUser is not set
+		numUser := h.NumUser.Val
+		if h.Subsystem == "vpn" && numUser == 0 && h.RemoteUserNumActive.Val > 0 {
+			numUser = h.RemoteUserNumActive.Val
+		}
+
 		data := map[string]float64{
-			"num_user":                 h.NumUser.Val,
+			"num_user":                 numUser,
 			"num_guest":                h.NumGuest.Val,
 			"num_iot":                  h.NumIot.Val,
 			"tx_bytes_r":               h.TxBytesR.Val,

--- a/pkg/influxunifi/site.go
+++ b/pkg/influxunifi/site.go
@@ -19,8 +19,15 @@ func (u *InfluxUnifi) batchSite(r report, s *unifi.Site) {
 			"gw_name":   h.GwName,
 			"lan_ip":    h.LanIP,
 		}
+
+		// For VPN subsystem, use RemoteUserNumActive for num_user if NumUser is not set
+		numUser := h.NumUser.Val
+		if h.Subsystem == "vpn" && numUser == 0 && h.RemoteUserNumActive.Val > 0 {
+			numUser = h.RemoteUserNumActive.Val
+		}
+
 		fields := map[string]any{
-			"num_user":                 h.NumUser.Val,
+			"num_user":                 numUser,
 			"num_guest":                h.NumGuest.Val,
 			"num_iot":                  h.NumIot.Val,
 			"tx_bytes-r":               h.TxBytesR.Int64(),

--- a/pkg/promunifi/site.go
+++ b/pkg/promunifi/site.go
@@ -146,7 +146,14 @@ func (u *promUnifi) exportSite(r report, s *unifi.Site) {
 				{u.Site.NumSw, gauge, h.NumSw, labels},
 			})
 		case "vpn":
+			// For VPN subsystem, use RemoteUserNumActive for NumUser if NumUser is not set
+			numUser := h.NumUser.Val
+			if numUser == 0 && h.RemoteUserNumActive.Val > 0 {
+				numUser = h.RemoteUserNumActive.Val
+			}
+
 			r.send([]*metric{
+				{u.Site.NumUser, gauge, numUser, labels},
 				{u.Site.RemoteUserNumActive, gauge, h.RemoteUserNumActive, labels},
 				{u.Site.RemoteUserNumInactive, gauge, h.RemoteUserNumInactive, labels},
 				{u.Site.RemoteUserRxBytes, counter, h.RemoteUserRxBytes, labels},


### PR DESCRIPTION
## Summary
Fixes #417 - VPN users now properly display in dashboards using the standard `num_user` field.

## Problem
Users reported that VPN user counts always showed **0** in Grafana dashboards, even when VPN connections were active. The issue affected both InfluxDB and Datadog users.

### Example Query (from issue #417):
```sql
SELECT "num_user" FROM "subsystems" WHERE subsystem='vpn'
```
This query always returned 0, making it impossible to monitor VPN usage through standard dashboard panels.

## Root Cause Analysis

### How UniFi Reports VPN Data
UniFi controllers use different fields for different subsystems:
- **Most subsystems** (wlan, lan, www): Populate `NumUser` directly
- **VPN subsystem**: Uses `RemoteUserNumActive` instead, leaving `NumUser` at 0

### Inconsistent Exporter Handling

**Prometheus** (pkg/promunifi/site.go:148-156):
- Had special case handling for VPN subsystem
- Exported `RemoteUserNumActive` but NOT `NumUser`
- Users querying Prometheus could use `remote_user_active` metric

**InfluxDB & Datadog**:
- No special handling for VPN subsystem
- Blindly exported all fields including `NumUser` (always 0 for VPN)
- Users couldn't see VPN metrics using standard `num_user` queries

This meant:
1. Existing dashboard queries for `num_user` failed for VPN
2. Users had to modify dashboards to query `remote_user_num_active` instead
3. This was undocumented and non-obvious

## Solution

For all three exporters, when processing VPN subsystem data:
```go
// For VPN subsystem, use RemoteUserNumActive for num_user if NumUser is not set
numUser := h.NumUser.Val
if h.Subsystem == "vpn" && numUser == 0 && h.RemoteUserNumActive.Val > 0 {
    numUser = h.RemoteUserNumActive.Val
}
```

This populates `num_user` with the actual VPN user count from `RemoteUserNumActive`.

### Benefits:
- ✅ **Backward compatible**: Existing queries using `num_user` now work
- ✅ **Consistent**: All subsystems use `num_user` field
- ✅ **No dashboard changes needed**: Users don't need to update queries
- ✅ **Preserved access**: `remote_user_num_active` field still available for those who need it

## Changes

### pkg/influxunifi/site.go
- Added VPN-specific fallback logic before creating fields map
- If subsystem is 'vpn', NumUser is 0, but RemoteUserNumActive > 0, use RemoteUserNumActive

### pkg/datadogunifi/site.go
- Same fallback logic as InfluxDB
- Ensures Datadog users see VPN metrics correctly

### pkg/promunifi/site.go
- Added `NumUser` metric to VPN case (line 156)
- Applied same fallback logic for consistency
- VPN case now exports both `NumUser` (with fallback) and `RemoteUserNumActive`

## Testing
- ✅ Code compiles successfully  
- ✅ All existing tests pass
- ✅ Verified logic only affects VPN subsystem when NumUser is 0

## Expected Behavior After Fix

### Before:
```sql
SELECT "num_user" FROM "subsystems" WHERE subsystem='vpn'
-- Returns: 0 (even with 5 active VPN users)
```

### After:
```sql
SELECT "num_user" FROM "subsystems" WHERE subsystem='vpn'
-- Returns: 5 (actual VPN user count)
```

### For users who already updated their dashboards:
```sql
SELECT "remote_user_num_active" FROM "subsystems" WHERE subsystem='vpn'
-- Still works: 5 (no breaking changes)
```

## Impact
Users monitoring VPN connections can now use standard dashboard panels without modification. The `num_user` field works consistently across all subsystems (wlan, lan, www, **vpn**), improving user experience and reducing confusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)