### PR TITLE
Fix Homebrew formula for newer Homebrew versions

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -547,7 +547,7 @@ brews:
       assert_match "unpoller v#{version}", shell_output("#{bin}/unpoller -v 2>&1", 2)
     install: |
       bin.install "unpoller"
-      etc.mkdir "unpoller"
+      (etc/"unpoller").mkpath
       etc.install "examples/up.conf" => "unpoller/up.conf.example"
     post_install: |
       etc.install "examples/up.conf" => "unpoller/up.conf"


### PR DESCRIPTION
## Summary
- Fix Homebrew installation error on macOS with Homebrew 4.3+
- Update GoReleaser config to use new Homebrew formula syntax

## Details

This PR fixes #742 by updating the Homebrew formula generation in `.goreleaser.yaml` to use the new directory creation syntax compatible with Homebrew 4.3+.

### Problem

Users installing unpoller via Homebrew on macOS 14.6+ with Homebrew 4.3.12 were encountering the error:
```
Error: An exception occurred within a child process:
  TypeError: no implicit conversion of String into Integer
```

As identified by @davidnewhall in #742, the issue was caused by the old `mkdir` syntax in the generated Homebrew formula.

### Solution

Updated the `install` section in the `brews` configuration:

**Before:**
```yaml
install: |
  bin.install "unpoller"
  etc.mkdir "unpoller"
  etc.install "examples/up.conf" => "unpoller/up.conf.example"
```

**After:**
```yaml
install: |
  bin.install "unpoller"
  (etc/"unpoller").mkpath
  etc.install "examples/up.conf" => "unpoller/up.conf.example"
```

The new syntax `(etc/"unpoller").mkpath` is the recommended way to create directories in modern Homebrew formulae and is backward compatible with older versions.

### Testing

- [x] Configuration syntax is valid YAML
- [ ] Next release will generate updated Homebrew formula
- [ ] Manual testing: Install from updated Homebrew tap after release

### Note

This change will take effect in the next release when GoReleaser regenerates the Homebrew formula in the `golift/homebrew-mugs` repository.

Fixes #742

🤖 Generated with [Claude Code](https://claude.com/claude-code)