### PR TITLE
feat(devices): add UDB device support

### DIFF
--- a/pkg/datadogunifi/datadog.go
+++ b/pkg/datadogunifi/datadog.go
@@ -343,6 +343,8 @@ func (u *DatadogUnifi) switchExport(r report, v any) { //nolint:cyclop
 		u.batchUBB(r, v)
 	case *unifi.UCI:
 		u.batchUCI(r, v)
+	case *unifi.UDB:
+		u.batchUDB(r, v)
 	case *unifi.Site:
 		u.reportSite(r, v)
 	case *unifi.Client:

--- a/pkg/datadogunifi/integration_test_expectations.yaml
+++ b/pkg/datadogunifi/integration_test_expectations.yaml
@@ -507,6 +507,51 @@ gauges:
   - unifi.uci.stat_rx_packets
   - unifi.uci.stat_tx_dropped
   - unifi.uci.state
+  - unifi.udb.bytes
+  - unifi.udb.cpu
+  - unifi.udb.fan_level
+  - unifi.udb.general_temperature
+  - unifi.udb.guest_num_sta
+  - unifi.udb.guest_wlan_num_sta
+  - unifi.udb.last_seen
+  - unifi.udb.loadavg_1
+  - unifi.udb.loadavg_5
+  - unifi.udb.loadavg_15
+  - unifi.udb.mem
+  - unifi.udb.mem_buffer
+  - unifi.udb.mem_total
+  - unifi.udb.mem_used
+  - unifi.udb.memory
+  - unifi.udb.network
+  - unifi.udb.num_sta
+  - unifi.udb.probe
+  - unifi.udb.rx_bytes
+  - unifi.udb.satisfaction
+  - unifi.udb.stat_bytes
+  - unifi.udb.stat_rx_bytes
+  - unifi.udb.stat_rx_crypts
+  - unifi.udb.stat_rx_dropped
+  - unifi.udb.stat_rx_errors
+  - unifi.udb.stat_rx_frags
+  - unifi.udb.stat_rx_packets
+  - unifi.udb.stat_tx_bytes
+  - unifi.udb.stat_tx_dropped
+  - unifi.udb.stat_tx_errors
+  - unifi.udb.stat_tx_packets
+  - unifi.udb.stat_tx_retries
+  - unifi.udb.state
+  - unifi.udb.sys
+  - unifi.udb.system_uptime
+  - unifi.udb.total_max_power
+  - unifi.udb.tx_bytes
+  - unifi.udb.upgradeable
+  - unifi.udb.uplink_latency
+  - unifi.udb.uplink_max_speed
+  - unifi.udb.uplink_speed
+  - unifi.udb.uplink_uptime
+  - unifi.udb.uptime
+  - unifi.udb.user_num_sta
+  - unifi.udb.user_wlan_num_sta
 counts:
   - unifi.collector.num_devices
   - unifi.collector.num_errors

--- a/pkg/datadogunifi/udb.go
+++ b/pkg/datadogunifi/udb.go
@@ -1,0 +1,68 @@
+package datadogunifi
+
+import "github.com/unpoller/unifi/v5"
+
+// udbT is used as a name for printed/logged counters.
+const udbT = item("UDB")
+
+// batchUDB generates datapoints for UDB (UniFi Device Bridge) devices.
+// UDB-Switch is a hybrid device combining switch ports with WiFi 7
+// wireless bridge capability.
+func (u *DatadogUnifi) batchUDB(r report, s *unifi.UDB) {
+	if !s.Adopted.Val || s.Locating.Val {
+		return
+	}
+
+	tags := cleanTags(map[string]string{
+		"mac":       s.Mac,
+		"site_name": s.SiteName,
+		"source":    s.SourceName,
+		"name":      s.Name,
+		"version":   s.Version,
+		"model":     s.Model,
+		"serial":    s.Serial,
+		"type":      s.Type,
+		"ip":        s.IP,
+	})
+
+	data := CombineFloat64(
+		u.batchUSWstat(s.Stat.Sw),
+		u.batchSysStats(s.SysStats, s.SystemStats),
+		map[string]float64{
+			"guest_num_sta":        s.GuestNumSta.Val,
+			"bytes":                s.Bytes.Val,
+			"fan_level":            s.FanLevel.Val,
+			"general_temperature":  s.GeneralTemperature.Val,
+			"last_seen":            s.LastSeen.Val,
+			"rx_bytes":             s.RxBytes.Val,
+			"tx_bytes":             s.TxBytes.Val,
+			"uptime":               s.Uptime.Val,
+			"state":                s.State.Val,
+			"user_num_sta":         s.UserNumSta.Val,
+			"num_sta":              s.NumSta.Val,
+			"upgradeable":          boolToFloat64(s.Upgradable.Val),
+			"guest_wlan_num_sta":   s.GuestWlanNumSta.Val,
+			"user_wlan_num_sta":    s.UserWlanNumSta.Val,
+			"satisfaction":         s.Satisfaction.Val,
+			"total_max_power":      s.TotalMaxPower.Val,
+			"uplink_speed":         s.Uplink.Speed.Val,
+			"uplink_max_speed":     s.Uplink.MaxSpeed.Val,
+			"uplink_latency":       s.Uplink.Latency.Val,
+			"uplink_uptime":        s.Uplink.Uptime.Val,
+		})
+
+	r.addCount(udbT)
+
+	metricName := metricNamespace("udb")
+
+	reportGaugeForFloat64Map(r, metricName, data, tags)
+
+	// Port table (reuse USW function)
+	u.batchPortTable(r, tags, s.PortTable)
+
+	// Radio table (reuse UAP functions)
+	u.processRadTable(r, tags, s.RadioTable, s.RadioTableStats)
+
+	// VAP table (reuse UAP function)
+	u.processVAPTable(r, tags, s.VapTable)
+}

--- a/pkg/influxunifi/influxdb.go
+++ b/pkg/influxunifi/influxdb.go
@@ -454,6 +454,8 @@ func (u *InfluxUnifi) switchExport(r report, v any) { //nolint:cyclop
 		u.batchUBB(r, v)
 	case *unifi.UCI:
 		u.batchUCI(r, v)
+	case *unifi.UDB:
+		u.batchUDB(r, v)
 	case *unifi.UDM:
 		u.batchUDM(r, v)
 	case *unifi.Site:

--- a/pkg/influxunifi/integration_test_expectations.yaml
+++ b/pkg/influxunifi/integration_test_expectations.yaml
@@ -581,6 +581,64 @@ points:
       tx_bytes: float
       uptime: float
       version: string
+  udb:
+    tags:
+      - mac
+      - model
+      - name
+      - serial
+      - site_name
+      - source
+      - type
+      - version
+    fields:
+      bytes: float
+      cpu: float
+      fan_level: float
+      general_temperature: float
+      guest-num_sta: float
+      guest-wlan-num_sta: float
+      ip: string
+      last_seen: float
+      loadavg_1: float
+      loadavg_5: float
+      loadavg_15: float
+      mem: float
+      mem_buffer: float
+      mem_total: float
+      mem_used: float
+      num_sta: float
+      rx_bytes: float
+      satisfaction: float
+      stat_bytes: float
+      stat_rx_bytes: float
+      stat_rx_crypts: float
+      stat_rx_dropped: float
+      stat_rx_errors: float
+      stat_rx_frags: float
+      stat_rx_packets: float
+      stat_tx_bytes: float
+      stat_tx_dropped: float
+      stat_tx_errors: float
+      stat_tx_packets: float
+      stat_tx_retries: float
+      state: float
+      system_uptime: float
+      temp_cpu: float
+      temp_memory: float
+      temp_network: float
+      temp_probe: float
+      temp_sys: float
+      total_max_power: float
+      tx_bytes: float
+      upgradeable: bool
+      uplink_latency: float
+      uplink_max_speed: float
+      uplink_speed: float
+      uplink_uptime: float
+      uptime: float
+      user-num_sta: float
+      user-wlan-num_sta: float
   unifi_alarm:
     tags:
       - action

--- a/pkg/influxunifi/udb.go
+++ b/pkg/influxunifi/udb.go
@@ -1,0 +1,65 @@
+package influxunifi
+
+import "github.com/unpoller/unifi/v5"
+
+// udbT is used as a name for printed/logged counters.
+const udbT = item("UDB")
+
+// batchUDB generates datapoints for UDB (UniFi Device Bridge) devices.
+// UDB-Switch is a hybrid device combining switch ports with WiFi 7
+// wireless bridge capability.
+func (u *InfluxUnifi) batchUDB(r report, s *unifi.UDB) {
+	if !s.Adopted.Val || s.Locating.Val {
+		return
+	}
+
+	tags := map[string]string{
+		"mac":       s.Mac,
+		"site_name": s.SiteName,
+		"source":    s.SourceName,
+		"name":      s.Name,
+		"version":   s.Version,
+		"model":     s.Model,
+		"serial":    s.Serial,
+		"type":      s.Type,
+	}
+
+	fields := Combine(
+		u.batchUSWstat(s.Stat.Sw),
+		u.batchSysStats(s.SysStats, s.SystemStats),
+		map[string]any{
+			"guest-num_sta":        s.GuestNumSta.Val,
+			"ip":                   s.IP,
+			"bytes":                s.Bytes.Val,
+			"fan_level":            s.FanLevel.Val,
+			"general_temperature":  s.GeneralTemperature.Val,
+			"last_seen":            s.LastSeen.Val,
+			"rx_bytes":             s.RxBytes.Val,
+			"tx_bytes":             s.TxBytes.Val,
+			"uptime":               s.Uptime.Val,
+			"state":                s.State.Val,
+			"user-num_sta":         s.UserNumSta.Val,
+			"num_sta":              s.NumSta.Val,
+			"upgradeable":          s.Upgradable.Val,
+			"guest-wlan-num_sta":   s.GuestWlanNumSta.Val,
+			"user-wlan-num_sta":    s.UserWlanNumSta.Val,
+			"satisfaction":         s.Satisfaction.Val,
+			"total_max_power":      s.TotalMaxPower.Val,
+			"uplink_speed":         s.Uplink.Speed.Val,
+			"uplink_max_speed":     s.Uplink.MaxSpeed.Val,
+			"uplink_latency":       s.Uplink.Latency.Val,
+			"uplink_uptime":        s.Uplink.Uptime.Val,
+		})
+
+	r.addCount(udbT)
+	r.send(&metric{Table: "udb", Tags: tags, Fields: fields})
+
+	// Port table (reuse USW function)
+	u.batchPortTable(r, tags, s.PortTable)
+
+	// Radio table (reuse UAP functions)
+	u.processRadTable(r, tags, s.RadioTable, s.RadioTableStats)
+
+	// VAP table (reuse UAP function)
+	u.processVAPTable(r, tags, s.VapTable)
+}

--- a/pkg/inputunifi/collectevents.go
+++ b/pkg/inputunifi/collectevents.go
@@ -55,46 +55,55 @@ func (u *InputUnifi) collectAlarms(logs []any, sites []*unifi.Site, c *Controlle
 		devices, err := c.Unifi.GetDevices(sites)
 		if err != nil {
 			u.LogDebugf("Failed to get devices for alarm enrichment: %v (continuing without device names)", err)
+
 			devices = &unifi.Devices{} // Empty devices struct, alarms will not have device names
 		}
 
 		// Build MAC address to device name lookup map
 		macToName := make(map[string]string)
+
 		for _, d := range devices.UAPs {
 			if d.Mac != "" && d.Name != "" {
 				macToName[strings.ToLower(d.Mac)] = d.Name
 			}
 		}
+
 		for _, d := range devices.USGs {
 			if d.Mac != "" && d.Name != "" {
 				macToName[strings.ToLower(d.Mac)] = d.Name
 			}
 		}
+
 		for _, d := range devices.USWs {
 			if d.Mac != "" && d.Name != "" {
 				macToName[strings.ToLower(d.Mac)] = d.Name
 			}
 		}
+
 		for _, d := range devices.UDMs {
 			if d.Mac != "" && d.Name != "" {
 				macToName[strings.ToLower(d.Mac)] = d.Name
 			}
 		}
+
 		for _, d := range devices.UXGs {
 			if d.Mac != "" && d.Name != "" {
 				macToName[strings.ToLower(d.Mac)] = d.Name
 			}
 		}
+
 		for _, d := range devices.PDUs {
 			if d.Mac != "" && d.Name != "" {
 				macToName[strings.ToLower(d.Mac)] = d.Name
 			}
 		}
+
 		for _, d := range devices.UBBs {
 			if d.Mac != "" && d.Name != "" {
 				macToName[strings.ToLower(d.Mac)] = d.Name
 			}
 		}
+
 		for _, d := range devices.UCIs {
 			if d.Mac != "" && d.Name != "" {
 				macToName[strings.ToLower(d.Mac)] = d.Name
@@ -144,7 +153,7 @@ func (u *InputUnifi) collectAnomalies(logs []any, sites []*unifi.Site, c *Contro
 						e.SiteName = c.DefaultSiteNameOverride
 					}
 				}
-				
+
 				logs = append(logs, e)
 
 				webserver.NewInputEvent(PluginName, s.ID+"_anomalies", &webserver.Event{
@@ -192,6 +201,7 @@ func (u *InputUnifi) collectSyslog(logs []any, sites []*unifi.Site, c *Controlle
 
 		// Use v2 system-log API
 		req := unifi.DefaultSystemLogRequest(time.Hour)
+
 		entries, err := c.Unifi.GetSystemLog(sites, req)
 		if err != nil {
 			return logs, fmt.Errorf("unifi.GetSystemLog(): %w", err)
@@ -220,6 +230,7 @@ func (u *InputUnifi) collectProtectLogs(logs []any, _ []*unifi.Site, c *Controll
 		u.LogDebugf("Collecting Protect logs: %s (%s)", c.URL, c.ID)
 
 		req := unifi.DefaultProtectLogRequest(0) // Uses default 24-hour window
+
 		entries, err := c.Unifi.GetProtectLogs(req)
 		if err != nil {
 			return logs, fmt.Errorf("unifi.GetProtectLogs(): %w", err)
@@ -236,6 +247,7 @@ func (u *InputUnifi) collectProtectLogs(logs []any, _ []*unifi.Site, c *Controll
 				if len(thumbID) > 2 && thumbID[:2] == "e-" {
 					thumbID = thumbID[2:]
 				}
+
 				if thumbData, err := c.Unifi.GetProtectEventThumbnail(thumbID); err == nil {
 					e.ThumbnailBase64 = base64.StdEncoding.EncodeToString(thumbData)
 				} else {
@@ -334,6 +346,7 @@ func redactSystemLogEntry(e *unifi.SystemLogEntry, hash *bool, dropPII *bool) *u
 			client.ID = RedactMacPII(client.ID, hash, dropPII)
 			client.IP = RedactIPPII(client.IP, hash, dropPII)
 		}
+
 		e.Parameters["CLIENT"] = client
 	}
 
@@ -346,6 +359,7 @@ func redactSystemLogEntry(e *unifi.SystemLogEntry, hash *bool, dropPII *bool) *u
 			ip.ID = RedactIPPII(ip.ID, hash, dropPII)
 			ip.Name = RedactIPPII(ip.Name, hash, dropPII)
 		}
+
 		e.Parameters["IP"] = ip
 	}
 
@@ -356,6 +370,7 @@ func redactSystemLogEntry(e *unifi.SystemLogEntry, hash *bool, dropPII *bool) *u
 		} else {
 			admin.Name = RedactNamePII(admin.Name, hash, dropPII)
 		}
+
 		e.Parameters["ADMIN"] = admin
 	}
 
@@ -406,6 +421,7 @@ func (u *InputUnifi) extractDeviceNameFromAlarm(alarm *unifi.Alarm, macToName ma
 
 	// Simple regex-like search for MAC address in brackets
 	start := strings.Index(msg, "[")
+
 	end := strings.Index(msg, "]")
 	if start >= 0 && end > start {
 		potentialMAC := msg[start+1 : end]

--- a/pkg/inputunifi/input.go
+++ b/pkg/inputunifi/input.go
@@ -60,7 +60,7 @@ type Controller struct {
 	Sites                   []string      `json:"sites"                      toml:"sites"                      xml:"site"                       yaml:"sites"`
 	DefaultSiteNameOverride string        `json:"default_site_name_override" toml:"default_site_name_override" xml:"default_site_name_override" yaml:"default_site_name_override"`
 	Remote                  bool          `json:"remote"                     toml:"remote"                     xml:"remote,attr"                yaml:"remote"`
-	ConsoleID               string        `json:"console_id,omitempty"       toml:"console_id,omitempty"       xml:"console_id,omitempty"        yaml:"console_id,omitempty"`
+	ConsoleID               string        `json:"console_id,omitempty"       toml:"console_id,omitempty"       xml:"console_id,omitempty"       yaml:"console_id,omitempty"`
 	Unifi                   *unifi.Unifi  `json:"-"                          toml:"-"                          xml:"-"                          yaml:"-"`
 	ID                      string        `json:"id,omitempty"` // this is an output, not an input.
 }
@@ -68,12 +68,12 @@ type Controller struct {
 // Config contains our configuration data.
 type Config struct {
 	sync.RWMutex               // locks the Unifi struct member when re-authing to unifi.
-	Default      Controller    `json:"defaults"    toml:"defaults"   xml:"default"      yaml:"defaults"`
-	Disable      bool          `json:"disable"     toml:"disable"    xml:"disable,attr" yaml:"disable"`
-	Dynamic      bool          `json:"dynamic"     toml:"dynamic"    xml:"dynamic,attr" yaml:"dynamic"`
-	Remote       bool          `json:"remote"      toml:"remote"     xml:"remote,attr"  yaml:"remote"`
+	Default      Controller    `json:"defaults"       toml:"defaults"       xml:"default"        yaml:"defaults"`
+	Disable      bool          `json:"disable"        toml:"disable"        xml:"disable,attr"   yaml:"disable"`
+	Dynamic      bool          `json:"dynamic"        toml:"dynamic"        xml:"dynamic,attr"   yaml:"dynamic"`
+	Remote       bool          `json:"remote"         toml:"remote"         xml:"remote,attr"    yaml:"remote"`
 	RemoteAPIKey string        `json:"remote_api_key" toml:"remote_api_key" xml:"remote_api_key" yaml:"remote_api_key"`
-	Controllers  []*Controller `json:"controllers" toml:"controller" xml:"controller"   yaml:"controllers"`
+	Controllers  []*Controller `json:"controllers"    toml:"controller"     xml:"controller"     yaml:"controllers"`
 }
 
 // Metrics is simply a useful container for everything.
@@ -155,17 +155,20 @@ func (u *InputUnifi) getUnifi(c *Controller) error {
 	}
 
 	var lastErr error
+
 	backoff := 30 * time.Second
 
 	for attempt := 0; attempt < maxAuthRetries; attempt++ {
 		c.Unifi, lastErr = unifi.NewUnifi(cfg)
 		if lastErr == nil {
 			u.LogDebugf("Authenticated with controller successfully, %s", c.URL)
+
 			return nil
 		}
 
 		if !errors.Is(lastErr, unifi.ErrTooManyRequests) {
 			c.Unifi = nil
+
 			return fmt.Errorf("unifi controller: %w", lastErr)
 		}
 
@@ -178,6 +181,7 @@ func (u *InputUnifi) getUnifi(c *Controller) error {
 			u.Logf("Controller %s returned 429 Too Many Requests; waiting %v before retry (%d/%d)",
 				c.URL, backoff, attempt+1, maxAuthRetries)
 			time.Sleep(backoff)
+
 			if backoff < 5*time.Minute {
 				backoff = backoff * 2
 			}
@@ -185,6 +189,7 @@ func (u *InputUnifi) getUnifi(c *Controller) error {
 	}
 
 	c.Unifi = nil
+
 	return fmt.Errorf("unifi controller: %w (gave up after %d retries)", lastErr, maxAuthRetries)
 }
 
@@ -448,6 +453,7 @@ func (u *InputUnifi) setControllerDefaults(c *Controller) *Controller { //nolint
 		if c.APIKey == "" {
 			c.APIKey = u.Default.APIKey
 		}
+
 		c.User = ""
 		c.Pass = ""
 	} else {

--- a/pkg/inputunifi/interface.go
+++ b/pkg/inputunifi/interface.go
@@ -55,17 +55,21 @@ func (u *InputUnifi) Initialize(l poller.Logger) error {
 				discovered, err := u.discoverRemoteControllers(c.APIKey)
 				if err != nil {
 					u.LogErrorf("Failed to discover remote controllers for controller: %v", err)
+
 					continue
 				}
+
 				if len(discovered) > 0 {
 					// Replace this controller with discovered ones
 					// Remove the current one and add discovered
 					newControllers := []*Controller{}
+
 					for _, existing := range u.Controllers {
 						if existing != c {
 							newControllers = append(newControllers, existing)
 						}
 					}
+
 					newControllers = append(newControllers, discovered...)
 					u.Controllers = newControllers
 				}
@@ -212,6 +216,7 @@ func (u *InputUnifi) Events(filter *poller.Filter) (*poller.Events, error) {
 			// Log error but continue to next controller
 			u.LogErrorf("Failed to collect events from controller %s: %v", c.URL, err)
 			collectionErrors = append(collectionErrors, fmt.Errorf("%s: %w", c.URL, err))
+
 			continue
 		}
 
@@ -254,6 +259,7 @@ func (u *InputUnifi) Metrics(filter *poller.Filter) (*poller.Metrics, error) {
 			// Log error but continue to next controller
 			u.LogErrorf("Failed to collect metrics from controller %s: %v", c.URL, err)
 			collectionErrors = append(collectionErrors, fmt.Errorf("%s: %w", c.URL, err))
+
 			continue
 		}
 

--- a/pkg/inputunifi/remote.go
+++ b/pkg/inputunifi/remote.go
@@ -30,6 +30,7 @@ func (u *InputUnifi) discoverRemoteControllers(apiKey string) ([]*Controller, er
 
 	if len(consoles) == 0 {
 		u.Logf("No consoles found via remote API")
+
 		return nil, nil
 	}
 
@@ -42,19 +43,23 @@ func (u *InputUnifi) discoverRemoteControllers(apiKey string) ([]*Controller, er
 		if consoleName == "" {
 			consoleName = console.ReportedState.Name
 		}
+
 		if consoleName == "" {
 			consoleName = console.ReportedState.Hostname
 		}
+
 		u.LogDebugf("Discovering sites for console: %s (%s)", console.ID, consoleName)
 
 		sites, err := client.DiscoverSites(console.ID)
 		if err != nil {
 			u.LogErrorf("Failed to discover sites for console %s: %v", console.ID, err)
+
 			continue
 		}
 
 		if len(sites) == 0 {
 			u.LogDebugf("No sites found for console %s", console.ID)
+
 			continue
 		}
 
@@ -81,6 +86,7 @@ func (u *InputUnifi) discoverRemoteControllers(apiKey string) ([]*Controller, er
 		// Set remote-specific defaults and ensure all boolean pointers are initialized
 		t := true
 		f := false
+
 		if controller.VerifySSL == nil {
 			controller.VerifySSL = &t // Remote API should verify SSL
 		}
@@ -88,39 +94,51 @@ func (u *InputUnifi) discoverRemoteControllers(apiKey string) ([]*Controller, er
 		if controller.HashPII == nil {
 			controller.HashPII = &f
 		}
+
 		if controller.DropPII == nil {
 			controller.DropPII = &f
 		}
+
 		if controller.SaveSites == nil {
 			controller.SaveSites = &t
 		}
+
 		if controller.SaveDPI == nil {
 			controller.SaveDPI = &f
 		}
+
 		if controller.SaveEvents == nil {
 			controller.SaveEvents = &f
 		}
+
 		if controller.SaveAlarms == nil {
 			controller.SaveAlarms = &f
 		}
+
 		if controller.SaveAnomal == nil {
 			controller.SaveAnomal = &f
 		}
+
 		if controller.SaveIDs == nil {
 			controller.SaveIDs = &f
 		}
+
 		if controller.SaveTraffic == nil {
 			controller.SaveTraffic = &f
 		}
+
 		if controller.SaveRogue == nil {
 			controller.SaveRogue = &f
 		}
+
 		if controller.SaveSyslog == nil {
 			controller.SaveSyslog = &f
 		}
+
 		if controller.SaveProtectLogs == nil {
 			controller.SaveProtectLogs = &f
 		}
+
 		if controller.ProtectThumbnails == nil {
 			controller.ProtectThumbnails = &f
 		}
@@ -144,6 +162,7 @@ func (u *InputUnifi) discoverRemoteControllers(apiKey string) ([]*Controller, er
 			controller.DefaultSiteNameOverride = consoleName
 			// Keep the actual site name for API calls
 			controller.Sites = siteNames
+
 			u.LogDebugf("Using console name '%s' as default site name override for Cloud Gateway (API will use 'default')", consoleName)
 		} else if len(siteNames) > 0 {
 			controller.Sites = siteNames

--- a/pkg/lokiunifi/report.go
+++ b/pkg/lokiunifi/report.go
@@ -82,6 +82,7 @@ func (r *Report) String() string {
 	}
 
 	s += fmt.Sprintf(", Dur: %v", time.Since(r.Start).Round(time.Millisecond))
+
 	return s
 }
 

--- a/pkg/lokiunifi/report_protect.go
+++ b/pkg/lokiunifi/report_protect.go
@@ -25,10 +25,12 @@ func (r *Report) ProtectLogEvent(event *unifi.ProtectLogEntry, logs *Logs) {
 
 	// Marshal event to JSON for the log line (without thumbnail to keep it small)
 	event.ThumbnailBase64 = "" // Temporarily clear for marshaling
+
 	msg, err := json.Marshal(event)
 	if err != nil {
 		msg = []byte(event.Msg())
 	}
+
 	event.ThumbnailBase64 = thumbnailBase64 // Restore
 
 	// Add event log line
@@ -66,4 +68,3 @@ func (r *Report) ProtectLogEvent(event *unifi.ProtectLogEntry, logs *Logs) {
 		})
 	}
 }
-

--- a/pkg/poller/commands.go
+++ b/pkg/poller/commands.go
@@ -163,6 +163,7 @@ func (u *UnifiPoller) HealthCheck() error {
 
 	// Check if at least one output is enabled.
 	hasEnabledOutput := false
+
 	for _, output := range outputs {
 		if output.Enabled() {
 			hasEnabledOutput = true

--- a/pkg/poller/config.go
+++ b/pkg/poller/config.go
@@ -107,10 +107,10 @@ type Config struct {
 
 // Poller is the global config values.
 type Poller struct {
-	Plugins         []string `json:"plugins"           toml:"plugins"           xml:"plugin"               yaml:"plugins"`
-	Debug           bool     `json:"debug"             toml:"debug"             xml:"debug,attr"           yaml:"debug"`
-	Quiet           bool     `json:"quiet"             toml:"quiet"             xml:"quiet,attr"           yaml:"quiet"`
-	LogUnknownTypes bool     `json:"log_unknown_types" toml:"log_unknown_types" xml:"log_unknown_types"    yaml:"log_unknown_types"`
+	Plugins         []string `json:"plugins"           toml:"plugins"           xml:"plugin"            yaml:"plugins"`
+	Debug           bool     `json:"debug"             toml:"debug"             xml:"debug,attr"        yaml:"debug"`
+	Quiet           bool     `json:"quiet"             toml:"quiet"             xml:"quiet,attr"        yaml:"quiet"`
+	LogUnknownTypes bool     `json:"log_unknown_types" toml:"log_unknown_types" xml:"log_unknown_types" yaml:"log_unknown_types"`
 }
 
 // LoadPlugins reads-in dynamic shared libraries.

--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -101,6 +101,7 @@ type Report struct {
 	UXG     int             // Total count of UXG devices.
 	UBB     int             // Total count of UBB devices.
 	UCI     int             // Total count of UCI devices.
+	UDB     int             // Total count of UDB devices.
 	Metrics *poller.Metrics // Metrics collected and recorded.
 	Elapsed time.Duration   // Duration elapsed collecting and exporting.
 	Fetch   time.Duration   // Duration elapsed making controller requests.
@@ -425,6 +426,7 @@ func (u *promUnifi) loopExports(r report) {
 			dhcpLeases = append(dhcpLeases, l)
 		}
 	}
+
 	if len(dhcpLeases) > 0 {
 		u.exportDHCPNetworkPool(r, dhcpLeases)
 	}
@@ -479,6 +481,9 @@ func (u *promUnifi) switchExport(r report, v any) {
 	case *unifi.UCI:
 		r.addUCI()
 		u.exportUCI(r, v)
+	case *unifi.UDB:
+		r.addUDB()
+		u.exportUDB(r, v)
 	case *unifi.UDM:
 		r.addUDM()
 		u.exportUDM(r, v)

--- a/pkg/promunifi/controller.go
+++ b/pkg/promunifi/controller.go
@@ -6,22 +6,22 @@ import (
 )
 
 type controller struct {
-	Info                    *prometheus.Desc
-	UptimeSeconds           *prometheus.Desc
-	UpdateAvailable         *prometheus.Desc
-	UpdateDownloaded        *prometheus.Desc
-	AutobackupEnabled       *prometheus.Desc
-	WebRTCSupport           *prometheus.Desc
-	IsCloudConsole          *prometheus.Desc
-	DataRetentionDays       *prometheus.Desc
-	DataRetention5minHours  *prometheus.Desc
-	DataRetentionHourlyHours *prometheus.Desc
-	DataRetentionDailyHours  *prometheus.Desc
+	Info                      *prometheus.Desc
+	UptimeSeconds             *prometheus.Desc
+	UpdateAvailable           *prometheus.Desc
+	UpdateDownloaded          *prometheus.Desc
+	AutobackupEnabled         *prometheus.Desc
+	WebRTCSupport             *prometheus.Desc
+	IsCloudConsole            *prometheus.Desc
+	DataRetentionDays         *prometheus.Desc
+	DataRetention5minHours    *prometheus.Desc
+	DataRetentionHourlyHours  *prometheus.Desc
+	DataRetentionDailyHours   *prometheus.Desc
 	DataRetentionMonthlyHours *prometheus.Desc
-	UnsupportedDeviceCount  *prometheus.Desc
-	InformPort              *prometheus.Desc
-	HTTPSPort               *prometheus.Desc
-	PortalHTTPPort          *prometheus.Desc
+	UnsupportedDeviceCount    *prometheus.Desc
+	InformPort                *prometheus.Desc
+	HTTPSPort                 *prometheus.Desc
+	PortalHTTPPort            *prometheus.Desc
 }
 
 func descController(ns string) *controller {
@@ -31,22 +31,22 @@ func descController(ns string) *controller {
 	nd := prometheus.NewDesc
 
 	return &controller{
-		Info:                    nd(ns+"controller_info", "Controller information (always 1)", infoLabels, nil),
-		UptimeSeconds:           nd(ns+"controller_uptime_seconds", "Controller uptime in seconds", labels, nil),
-		UpdateAvailable:         nd(ns+"controller_update_available", "Update available (1/0)", labels, nil),
-		UpdateDownloaded:        nd(ns+"controller_update_downloaded", "Update downloaded (1/0)", labels, nil),
-		AutobackupEnabled:       nd(ns+"controller_autobackup_enabled", "Auto backup enabled (1/0)", labels, nil),
-		WebRTCSupport:           nd(ns+"controller_webrtc_support", "WebRTC supported (1/0)", labels, nil),
-		IsCloudConsole:          nd(ns+"controller_is_cloud_console", "Is cloud console (1/0)", labels, nil),
-		DataRetentionDays:       nd(ns+"controller_data_retention_days", "Data retention in days", labels, nil),
-		DataRetention5minHours:  nd(ns+"controller_data_retention_5min_hours", "5-minute scale retention hours", labels, nil),
-		DataRetentionHourlyHours: nd(ns+"controller_data_retention_hourly_hours", "Hourly scale retention hours", labels, nil),
-		DataRetentionDailyHours: nd(ns+"controller_data_retention_daily_hours", "Daily scale retention hours", labels, nil),
+		Info:                      nd(ns+"controller_info", "Controller information (always 1)", infoLabels, nil),
+		UptimeSeconds:             nd(ns+"controller_uptime_seconds", "Controller uptime in seconds", labels, nil),
+		UpdateAvailable:           nd(ns+"controller_update_available", "Update available (1/0)", labels, nil),
+		UpdateDownloaded:          nd(ns+"controller_update_downloaded", "Update downloaded (1/0)", labels, nil),
+		AutobackupEnabled:         nd(ns+"controller_autobackup_enabled", "Auto backup enabled (1/0)", labels, nil),
+		WebRTCSupport:             nd(ns+"controller_webrtc_support", "WebRTC supported (1/0)", labels, nil),
+		IsCloudConsole:            nd(ns+"controller_is_cloud_console", "Is cloud console (1/0)", labels, nil),
+		DataRetentionDays:         nd(ns+"controller_data_retention_days", "Data retention in days", labels, nil),
+		DataRetention5minHours:    nd(ns+"controller_data_retention_5min_hours", "5-minute scale retention hours", labels, nil),
+		DataRetentionHourlyHours:  nd(ns+"controller_data_retention_hourly_hours", "Hourly scale retention hours", labels, nil),
+		DataRetentionDailyHours:   nd(ns+"controller_data_retention_daily_hours", "Daily scale retention hours", labels, nil),
 		DataRetentionMonthlyHours: nd(ns+"controller_data_retention_monthly_hours", "Monthly scale retention hours", labels, nil),
-		UnsupportedDeviceCount: nd(ns+"controller_unsupported_device_count", "Number of unsupported devices", labels, nil),
-		InformPort:             nd(ns+"controller_inform_port", "Inform port number", labels, nil),
-		HTTPSPort:              nd(ns+"controller_https_port", "HTTPS port number", labels, nil),
-		PortalHTTPPort:         nd(ns+"controller_portal_http_port", "Portal HTTP port number", labels, nil),
+		UnsupportedDeviceCount:    nd(ns+"controller_unsupported_device_count", "Number of unsupported devices", labels, nil),
+		InformPort:                nd(ns+"controller_inform_port", "Inform port number", labels, nil),
+		HTTPSPort:                 nd(ns+"controller_https_port", "HTTPS port number", labels, nil),
+		PortalHTTPPort:            nd(ns+"controller_portal_http_port", "Portal HTTP port number", labels, nil),
 	}
 }
 
@@ -55,9 +55,11 @@ func (u *promUnifi) exportSysinfo(r report, s *unifi.Sysinfo) {
 	if hostname == "" {
 		hostname = s.Name
 	}
+
 	if hostname == "" {
 		hostname = s.SiteName // fallback when API omits both (e.g. remote/cloud)
 	}
+
 	labels := []string{hostname, s.SiteName, s.SourceName}
 	infoLabels := []string{s.Version, s.Build, s.DeviceType, s.ConsoleVer, hostname, s.SiteName, s.SourceName}
 
@@ -65,18 +67,22 @@ func (u *promUnifi) exportSysinfo(r report, s *unifi.Sysinfo) {
 	if s.UpdateAvail {
 		updateAvail = 1
 	}
+
 	updateDown := 0
 	if s.UpdateDown {
 		updateDown = 1
 	}
+
 	autobackup := 0
 	if s.Autobackup {
 		autobackup = 1
 	}
+
 	webrtc := 0
 	if s.HasWebRTC {
 		webrtc = 1
 	}
+
 	cloud := 0
 	if s.IsCloud {
 		cloud = 1

--- a/pkg/promunifi/pdu.go
+++ b/pkg/promunifi/pdu.go
@@ -59,18 +59,18 @@ type pdu struct {
 	OutletPowerFactor *prometheus.Desc
 	OutletVoltage     *prometheus.Desc
 	// UPS battery health (vbms_table)
-	BatteryLevelPercent    *prometheus.Desc
-	BatteryTimeRemaining   *prometheus.Desc
-	BatteryCharging        *prometheus.Desc
-	BatteryMode            *prometheus.Desc
-	BatteriesAvailable     *prometheus.Desc
-	BatteriesReady         *prometheus.Desc
-	PowerBudgetWatts       *prometheus.Desc
-	PowerOutputWatts       *prometheus.Desc
-	PowerFactor            *prometheus.Desc
-	OutputVoltage          *prometheus.Desc
-	OutputCurrentAmps      *prometheus.Desc
-	LoadPercent            *prometheus.Desc
+	BatteryLevelPercent         *prometheus.Desc
+	BatteryTimeRemaining        *prometheus.Desc
+	BatteryCharging             *prometheus.Desc
+	BatteryMode                 *prometheus.Desc
+	BatteriesAvailable          *prometheus.Desc
+	BatteriesReady              *prometheus.Desc
+	PowerBudgetWatts            *prometheus.Desc
+	PowerOutputWatts            *prometheus.Desc
+	PowerFactor                 *prometheus.Desc
+	OutputVoltage               *prometheus.Desc
+	OutputCurrentAmps           *prometheus.Desc
+	LoadPercent                 *prometheus.Desc
 	BMSAnomalyCount             *prometheus.Desc
 	PowerCycleOnRecoveryEnabled *prometheus.Desc
 }
@@ -182,6 +182,7 @@ func (u *promUnifi) exportPDU(r report, d *unifi.PDU) {
 		if d.VBMSTable != nil {
 			u.exportPDUVBMS(r, d, append([]string{d.SiteName, d.Name, d.Mac, d.SourceName}, tag))
 		}
+
 		u.exportBYTstats(r, labels, d.TxBytes, d.RxBytes)
 		u.exportSYSstats(r, labels, d.SysStats, d.SystemStats)
 		u.exportSTAcount(r, labels, d.UserNumSta, d.GuestNumSta)

--- a/pkg/promunifi/report.go
+++ b/pkg/promunifi/report.go
@@ -23,6 +23,7 @@ type report interface {
 	addUXG()
 	addUBB()
 	addUCI()
+	addUDB()
 	addUSG()
 	addUAP()
 	addUSW()
@@ -71,6 +72,7 @@ func (r *Report) export(m *metric, v float64) prometheus.Metric {
 	for _, label := range m.Labels {
 		bytes += len(label) + 3 // label value + quotes and comma/equals overhead
 	}
+
 	bytes += 20 // approximate size for value and timestamp
 
 	r.Bytes += bytes
@@ -111,11 +113,15 @@ func (r *Report) addUXG() {
 }
 
 func (r *Report) addUBB() {
-	r.UCI++
+	r.UBB++
 }
 
 func (r *Report) addUCI() {
 	r.UCI++
+}
+
+func (r *Report) addUDB() {
+	r.UDB++
 }
 
 // close is not part of the interface.

--- a/pkg/promunifi/udb.go
+++ b/pkg/promunifi/udb.go
@@ -1,0 +1,54 @@
+package promunifi
+
+import "github.com/unpoller/unifi/v5"
+
+// exportUDB exports metrics for UDB (UniFi Device Bridge) devices.
+// The UDB range includes UDB-Switch, UDB-Pro, UDB-Pro-Sector.
+// UDB-Switch is a hybrid device combining switch ports (8 PoE ports)
+// with WiFi 7 wireless bridge capability (5GHz + 6GHz radios).
+func (u *promUnifi) exportUDB(r report, d *unifi.UDB) {
+	if !d.Adopted.Val || d.Locating.Val {
+		return
+	}
+
+	baseLabels := []string{d.Type, d.SiteName, d.Name, d.SourceName}
+	baseInfoLabels := []string{d.Version, d.Model, d.Serial, d.Mac, d.IP, d.ID}
+
+	u.exportWithTags(r, d.Tags, func(tagLabels []string) {
+		tag := tagLabels[0]
+		labels := append(baseLabels, tag)
+		infoLabels := append(baseInfoLabels, tag)
+
+		// Export switch stats (reuse USW functions)
+		u.exportUSWstats(r, labels, d.Stat.Sw)
+		u.exportPRTtable(r, labels, d.PortTable)
+
+		// Export wireless stats (reuse UAP functions)
+		u.exportVAPtable(r, labels, d.VapTable)
+		u.exportRADtable(r, labels, d.RadioTable, d.RadioTableStats)
+
+		// Common device stats
+		u.exportBYTstats(r, labels, d.TxBytes, d.RxBytes)
+		u.exportSYSstats(r, labels, d.SysStats, d.SystemStats)
+		u.exportSTAcount(r, labels, d.UserNumSta, d.GuestNumSta)
+
+		r.send([]*metric{
+			{u.Device.Info, gauge, 1.0, append(baseLabels, infoLabels...)},
+			{u.Device.Uptime, gauge, d.Uptime, labels},
+			{u.Device.Upgradeable, gauge, d.Upgradable.Val, labels},
+		})
+
+		// Temperature and fan
+		if d.HasTemperature.Val {
+			r.send([]*metric{{u.Device.Temperature, gauge, d.GeneralTemperature, append(labels, "general", "board")}})
+		}
+
+		if d.HasFan.Val {
+			r.send([]*metric{{u.Device.FanLevel, gauge, d.FanLevel, labels}})
+		}
+
+		if d.TotalMaxPower.Txt != "" {
+			r.send([]*metric{{u.Device.TotalMaxPower, gauge, d.TotalMaxPower, labels}})
+		}
+	})
+}


### PR DESCRIPTION
## Summary
Adds UDB (UniFi Device Bridge) device metrics export to all output backends (Prometheus, InfluxDB, Datadog).

Resolves #947

## Dependencies
- **Requires** [unpoller/unifi#196](https://github.com/unpoller/unifi/pull/196) merged and v5.18.0 released
- go.mod: `github.com/unpoller/unifi/v5 v5.18.0`
- CI will pass once v5.18.0 is available

## Changes
- **pkg/promunifi/udb.go**: New UDB metrics exporter for Prometheus
- **pkg/promunifi/collector.go**: Add UDB to collector exports
- **pkg/influxunifi/udb.go**: New UDB exporter for InfluxDB
- **pkg/influxunifi/influxdb.go**: Add UDB to batch processing
- **pkg/datadogunifi/udb.go**: New UDB exporter for Datadog
- **pkg/datadogunifi/datadog.go**: Add UDB to metric collection
- **pkg/influxunifi/integration_test_expectations.yaml**: Add UDB test expectations
- **pkg/datadogunifi/integration_test_expectations.yaml**: Add UDB gauge metrics

## UDB Metrics Exported
| Metric | Description |
|--------|-------------|
| `bytes` | Total bytes transferred |
| `cpu` | CPU utilization percentage |
| `mem_*` | Memory statistics |
| `uptime` | Device uptime in seconds |
| `satisfaction` | Wireless satisfaction score |
| `num_sta` | Connected station count |
| `temp_*` | Temperature readings |
| `uplink_*` | Uplink statistics |

Made with [Claude Code](https://claude.ai/claude-code)