### PR TITLE
fix(inputunifi): recover from GetActiveDHCPLeasesWithAssociations panic (#965)

### DIFF
--- a/pkg/inputunifi/collector.go
+++ b/pkg/inputunifi/collector.go
@@ -188,13 +188,23 @@ func (u *InputUnifi) pollController(c *Controller) (*poller.Metrics, error) {
 		u.LogDebugf("Found %d SpeedTests entries", len(m.SpeedTests))
 	}
 
-	// Get DHCP leases with associations
-	if m.DHCPLeases, err = c.Unifi.GetActiveDHCPLeasesWithAssociations(sites); err != nil {
-		// Don't fail collection if DHCP leases fail - older controllers may not have this endpoint
-		u.LogDebugf("unifi.GetActiveDHCPLeasesWithAssociations(%s): %v (continuing)", c.URL, err)
-	} else {
-		u.LogDebugf("Found %d DHCPLeases entries", len(m.DHCPLeases))
-	}
+	// Get DHCP leases with associations.
+	// Wrapped in recover so a nil-pointer panic in the library (e.g. when a 401 causes nil devices)
+	// never crashes the poller. See https://github.com/unpoller/unpoller/issues/965
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				u.LogErrorf("GetActiveDHCPLeasesWithAssociations panic recovered (see issue #965): %v", r)
+			}
+		}()
+
+		if m.DHCPLeases, err = c.Unifi.GetActiveDHCPLeasesWithAssociations(sites); err != nil {
+			// Don't fail collection if DHCP leases fail - older controllers may not have this endpoint
+			u.LogDebugf("unifi.GetActiveDHCPLeasesWithAssociations(%s): %v (continuing)", c.URL, err)
+		} else {
+			u.LogDebugf("Found %d DHCPLeases entries", len(m.DHCPLeases))
+		}
+	}()
 
 	// Get WAN enriched configuration
 	if m.WANConfigs, err = c.Unifi.GetWANEnrichedConfiguration(sites); err != nil {


### PR DESCRIPTION
## Summary

- Wraps `GetActiveDHCPLeasesWithAssociations` in an anonymous function with a `defer recover()` so a nil-pointer panic in the unifi library never crashes the poller process
- Mirrors the existing pattern already used for `updateWeb` in the same function
- The underlying bug was in unifi library v5.18.0 (used by unpoller 2.34.0): when the controller returned 401 on the devices endpoint, `GetDevices` returned nil which was then dereferenced without a guard — causing a SIGSEGV and docker container restart
- The unifi library v5.20.0 (current) already added the `if devices != nil` guard, but this recover wrapper provides defense-in-depth for any future panics in this call path

Fixes #965

## Test plan

- [x] Verify the poller continues collecting metrics after a 401 on the DHCP-related endpoints (auth expiry scenario)
- [x] Confirm the error is logged at `ERROR` level (not silently swallowed) when a panic is recovered
- [x] Build passes: `go build ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)