### PR TITLE
fix: remove age==0 guard that silently dropped all rogue AP metrics

### DIFF
--- a/pkg/datadogunifi/uap.go
+++ b/pkg/datadogunifi/uap.go
@@ -11,10 +11,6 @@ const uapT = item("UAP")
 
 // batchRogueAP generates metric points for neighboring access points.
 func (u *DatadogUnifi) batchRogueAP(r report, s *unifi.RogueAP) {
-	if s.Age.Val == 0 {
-		return // only keep metrics for things that are recent.
-	}
-
 	tags := cleanTags(map[string]string{
 		"security":   s.Security,
 		"oui":        s.Oui,

--- a/pkg/influxunifi/uap.go
+++ b/pkg/influxunifi/uap.go
@@ -11,10 +11,6 @@ const uapT = item("UAP")
 
 // batchRogueAP generates metric points for neighboring access points.
 func (u *InfluxUnifi) batchRogueAP(r report, s *unifi.RogueAP) {
-	if s.Age.Val == 0 {
-		return // only keep metrics for things that are recent.
-	}
-
 	r.send(&metric{
 		Table: "uap_rogue",
 		Tags: map[string]string{

--- a/pkg/promunifi/uap.go
+++ b/pkg/promunifi/uap.go
@@ -193,10 +193,6 @@ func descUAP(ns string) *uap { // nolint: funlen
 }
 
 func (u *promUnifi) exportRogueAP(r report, d *unifi.RogueAP) {
-	if d.Age.Val == 0 {
-		return // only keep things that are recent.
-	}
-
 	labels := []string{
 		d.Security, d.Oui, d.Band, d.Bssid, d.ApMac, d.Radio, d.RadioName, d.SiteName, d.Essid, d.SourceName,
 	}


### PR DESCRIPTION
## Summary

- `save_rogue = true` collected data from the controller (debug logs confirm the API returns data) but nothing was ever written to InfluxDB, Prometheus, or Datadog.
- All three output backends had identical guards: `if s.Age.Val == 0 { return }` with the comment "only keep metrics for things that are recent."
- The logic is inverted: `Age == 0` means the entry is brand-new **or** (the common case based on user reports) that the UniFi controller does not include an `age` field in newer firmware, so `FlexInt` defaults to `0`. This silently discarded every rogue AP record.
- Removed the guard in `pkg/influxunifi/uap.go`, `pkg/datadogunifi/uap.go`, and `pkg/promunifi/uap.go`. The data is fetched on-demand; if the user enabled `save_rogue`, they want all of it.

Fixes #405

## Test plan

- [ ] Enable `save_rogue = true`, confirm `uap_rogue` measurement appears in InfluxDB after next poll
- [ ] Confirm Prometheus `rogueap_*` metrics are exported
- [ ] Run `go test ./...` — all existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)