### PR TITLE
feat(promunifi): add unifi_controller_up gauge metric

### DIFF
--- a/pkg/inputunifi/interface.go
+++ b/pkg/inputunifi/interface.go
@@ -256,7 +256,32 @@ func (u *InputUnifi) Metrics(filter *poller.Filter) (*poller.Metrics, error) {
 			// Log error but continue to next controller
 			u.LogErrorf("Failed to collect metrics from controller %s: %v", c.URL, err)
 			collectionErrors = append(collectionErrors, fmt.Errorf("%s: %w", c.URL, err))
+
+			// Record controller as down so output plugins can expose the status.
+			source := c.URL
+			if c.ID != "" {
+				source = c.ID
+			}
+
+			metrics.ControllerStatuses = append(metrics.ControllerStatuses, poller.ControllerStatus{
+				Source: source,
+				Up:     false,
+			})
+
 			continue
+		}
+
+		// Record controller as up.
+		source := c.URL
+		if c.ID != "" {
+			source = c.ID
+		}
+
+		if m != nil {
+			m.ControllerStatuses = append(m.ControllerStatuses, poller.ControllerStatus{
+				Source: source,
+				Up:     true,
+			})
 		}
 
 		metrics = poller.AppendMetrics(metrics, m)

--- a/pkg/poller/config.go
+++ b/pkg/poller/config.go
@@ -79,20 +79,30 @@ type Flags struct {
 	*pflag.FlagSet
 }
 
+// ControllerStatus carries the per-controller poll result (up/down) so that
+// output plugins can expose a health gauge without knowing UniFi internals.
+type ControllerStatus struct {
+	// Source is a stable identifier for the controller (URL or configured ID).
+	Source string
+	// Up is true when the last poll of this controller succeeded.
+	Up bool
+}
+
 // Metrics is a type shared by the exporting and reporting packages.
 type Metrics struct {
-	TS             time.Time
-	Sites          []any
-	Clients        []any
-	SitesDPI       []any
-	ClientsDPI     []any
-	Devices        []any
-	RogueAPs       []any
-	SpeedTests     []any
-	CountryTraffic []any
-	DHCPLeases     []any
-	WANConfigs     []any
-	Sysinfos       []any
+	TS                 time.Time
+	Sites              []any
+	Clients            []any
+	SitesDPI           []any
+	ClientsDPI         []any
+	Devices            []any
+	RogueAPs           []any
+	SpeedTests         []any
+	CountryTraffic     []any
+	DHCPLeases         []any
+	WANConfigs         []any
+	Sysinfos           []any
+	ControllerStatuses []ControllerStatus
 }
 
 // Events defines the type for log entries.

--- a/pkg/poller/inputs.go
+++ b/pkg/poller/inputs.go
@@ -277,6 +277,7 @@ func AppendMetrics(existing *Metrics, m *Metrics) *Metrics {
 	existing.DHCPLeases = append(existing.DHCPLeases, m.DHCPLeases...)
 	existing.WANConfigs = append(existing.WANConfigs, m.WANConfigs...)
 	existing.Sysinfos = append(existing.Sysinfos, m.Sysinfos...)
+	existing.ControllerStatuses = append(existing.ControllerStatuses, m.ControllerStatuses...)
 
 	return existing
 }

--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -50,6 +50,8 @@ type promUnifi struct {
 	DHCPLease      *dhcplease
 	WAN            *wan
 	Controller     *controller
+	// controllerUp tracks per-controller poll success (1) or failure (0).
+	controllerUp *prometheus.GaugeVec
 	// This interface is passed to the Collect() method. The Collect method uses
 	// this interface to retrieve the latest UniFi measurements and export them.
 	Collector poller.Collect
@@ -213,6 +215,10 @@ func (u *promUnifi) Run(c poller.Collect) error {
 	u.DHCPLease = descDHCPLease(u.Namespace + "_")
 	u.WAN = descWAN(u.Namespace + "_")
 	u.Controller = descController(u.Namespace + "_")
+	u.controllerUp = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: u.Namespace + "_controller_up",
+		Help: "Whether the last poll of the UniFi controller succeeded (1) or failed (0).",
+	}, []string{"source"})
 
 	mux := http.NewServeMux()
 	promver.Version = version.Version
@@ -221,6 +227,7 @@ func (u *promUnifi) Run(c poller.Collect) error {
 
 	webserver.UpdateOutput(&webserver.Output{Name: PluginName, Config: u.Config})
 	prometheus.MustRegister(collectors.NewBuildInfoCollector())
+	prometheus.MustRegister(u.controllerUp)
 	prometheus.MustRegister(u)
 	mux.Handle("/metrics", promhttp.HandlerFor(prometheus.DefaultGatherer,
 		promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError},
@@ -338,6 +345,18 @@ func (u *promUnifi) collect(ch chan<- prometheus.Metric, filter *poller.Filter) 
 		u.LogErrorf("metric fetch failed: %v", err)
 
 		return
+	}
+
+	// Export per-controller up/down gauge values.
+	if u.controllerUp != nil && r.Metrics != nil {
+		for _, cs := range r.Metrics.ControllerStatuses {
+			val := 0.0
+			if cs.Up {
+				val = 1.0
+			}
+
+			u.controllerUp.WithLabelValues(cs.Source).Set(val)
+		}
 	}
 
 	// Pass Report interface into our collecting and reporting methods.


### PR DESCRIPTION
## Summary

Implements the `<namespace>_controller_up` Prometheus gauge metric requested in #356.

- Adds a `ControllerStatus` type to `pkg/poller` so any output plugin can consume per-controller poll health without coupling to UniFi internals.
- `pkg/inputunifi` records `Up: true` on successful controller polls and `Up: false` on failed ones (while continuing to poll remaining controllers as before).
- `pkg/promunifi` registers a `prometheus.GaugeVec` named `<namespace>_controller_up` with a `source` label (controller URL or configured ID), and sets it to `1`/`0` after every Collect cycle.

Example metric after a successful poll:

```
unpoller_controller_up{source="https://192.168.1.1:8443"} 1
```

And on failure:

```
unpoller_controller_up{source="https://192.168.1.1:8443"} 0
```

## Test plan

- [x] `go build ./...` passes with no errors
- [x] `go test ./...` passes with no failures
- [x] Manual verification: run unpoller with a healthy controller and confirm the gauge shows `1`; simulate a controller outage and confirm it drops to `0`

Closes #356

🤖 Generated with [Claude Code](https://claude.com/claude-code)