### PR TITLE
feat(lokiunifi): add richer low-cardinality stream labels

### DIFF
--- a/pkg/lokiunifi/report_alarm.go
+++ b/pkg/lokiunifi/report_alarm.go
@@ -27,9 +27,12 @@ func (r *Report) Alarm(event *unifi.Alarm, logs *Logs) {
 	logs.Streams = append(logs.Streams, LogStream{
 		Entries: [][]string{{strconv.FormatInt(event.Datetime.UnixNano(), 10), string(msg)}},
 		Labels: CleanLabels(MergeLabels(map[string]string{
-			"application": "unifi_alarm",
-			"source":      event.SourceName,
-			"site_name":   event.SiteName,
+			"application":        "unifi_alarm",
+			"job":                "unpoller",
+			"source":             event.SourceName,
+			"site_name":          event.SiteName,
+			"event_type":         event.Key,
+			"inner_alert_action": event.InnerAlertAction,
 		}, r.ExtraLabels)),
 	})
 }

--- a/pkg/lokiunifi/report_anomaly.go
+++ b/pkg/lokiunifi/report_anomaly.go
@@ -28,6 +28,7 @@ func (r *Report) Anomaly(event *unifi.Anomaly, logs *Logs) {
 		Entries: [][]string{{strconv.FormatInt(event.Datetime.UnixNano(), 10), string(msg)}},
 		Labels: CleanLabels(MergeLabels(map[string]string{
 			"application": "unifi_anomaly",
+			"job":         "unpoller",
 			"source":      event.SourceName,
 			"site_name":   event.SiteName,
 		}, r.ExtraLabels)),

--- a/pkg/lokiunifi/report_event.go
+++ b/pkg/lokiunifi/report_event.go
@@ -29,6 +29,7 @@ func (r *Report) Event(event *unifi.Event, logs *Logs) {
 		Entries: [][]string{{strconv.FormatInt(event.Datetime.UnixNano(), 10), string(msg)}},
 		Labels: CleanLabels(MergeLabels(map[string]string{
 			"application": "unifi_event",
+			"job":         "unpoller",
 			"site_name":   event.SiteName,
 			"source":      event.SourceName,
 		}, r.ExtraLabels)),
@@ -54,6 +55,7 @@ func (r *Report) SystemLogEvent(event *unifi.SystemLogEntry, logs *Logs) {
 		Entries: [][]string{{strconv.FormatInt(event.Datetime().UnixNano(), 10), string(msg)}},
 		Labels: CleanLabels(MergeLabels(map[string]string{
 			"application": "unifi_system_log",
+			"job":         "unpoller",
 			"site_name":   event.SiteName,
 			"source":      event.SourceName,
 			"category":    event.Category,

--- a/pkg/lokiunifi/report_ids.go
+++ b/pkg/lokiunifi/report_ids.go
@@ -27,9 +27,12 @@ func (r *Report) IDs(event *unifi.IDS, logs *Logs) {
 	logs.Streams = append(logs.Streams, LogStream{
 		Entries: [][]string{{strconv.FormatInt(event.Datetime.UnixNano(), 10), string(msg)}},
 		Labels: CleanLabels(MergeLabels(map[string]string{
-			"application": "unifi_ids",
-			"source":      event.SourceName,
-			"site_name":   event.SiteName,
+			"application":        "unifi_ids",
+			"job":                "unpoller",
+			"source":             event.SourceName,
+			"site_name":          event.SiteName,
+			"event_type":         event.EventType,
+			"inner_alert_action": event.InnerAlertAction,
 		}, r.ExtraLabels)),
 	})
 }

--- a/pkg/lokiunifi/report_protect.go
+++ b/pkg/lokiunifi/report_protect.go
@@ -36,6 +36,7 @@ func (r *Report) ProtectLogEvent(event *unifi.ProtectLogEntry, logs *Logs) {
 		Entries: [][]string{{strconv.FormatInt(event.Datetime().UnixNano(), 10), string(msg)}},
 		Labels: CleanLabels(MergeLabels(map[string]string{
 			"application": "unifi_protect_log",
+			"job":         "unpoller",
 			"source":      event.SourceName,
 			"event_type":  event.GetEventType(),
 			"category":    event.GetCategory(),
@@ -59,6 +60,7 @@ func (r *Report) ProtectLogEvent(event *unifi.ProtectLogEntry, logs *Logs) {
 			Entries: [][]string{{strconv.FormatInt(event.Datetime().UnixNano()+1, 10), string(thumbnailJSON)}},
 			Labels: CleanLabels(MergeLabels(map[string]string{
 				"application": "unifi_protect_thumbnail",
+				"job":         "unpoller",
 				"source":      event.SourceName,
 				"event_id":    event.ID,
 				"camera":      event.Camera,


### PR DESCRIPTION
## Summary

Closes #932 (partial).

- Adds `job=unpoller` to every Loki stream (`unifi_alarm`, `unifi_anomaly`, `unifi_event`, `unifi_ids`, `unifi_system_log`, `unifi_protect_log`, `unifi_protect_thumbnail`). This follows the standard Grafana/Loki convention and allows filtering all unpoller logs with `{job="unpoller"}`.
- Adds `event_type` and `inner_alert_action` labels to **IDS** streams, sourced from the low-cardinality `EventType` (`alert`, `dns`, `flow`, etc.) and `InnerAlertAction` (`block`, `alert`) fields on `unifi.IDS`.
- Adds `event_type` and `inner_alert_action` labels to **Alarm** streams, sourced from `Key` and `InnerAlertAction` on `unifi.Alarm`.
- No new labels added to **Anomaly**: the `unifi.Anomaly` struct only contains `Anomaly` (free-text description), `Datetime`, `DeviceMAC`, `SiteName`, and `SourceName` — none of which are low-cardinality label candidates beyond what already exists.

## Label cardinality rationale

| Label | Values | Why low-cardinality |
|---|---|---|
| `job` | `unpoller` | constant |
| `event_type` | `alert`, `dns`, `flow`, `http`, … | small fixed set from Suricata |
| `inner_alert_action` | `block`, `alert` | two values |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes
- [x] Labels verified against `unifi.IDS` and `unifi.Alarm` structs in `unifi/v5@v5.20.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)