### PR TITLE
feat: export site_to_site_enabled VPN metric for InfluxDB and Prometheus

### DIFF
--- a/pkg/influxunifi/integration_test_expectations.yaml
+++ b/pkg/influxunifi/integration_test_expectations.yaml
@@ -211,6 +211,7 @@ points:
       rx_bytes-r: int
       speedtest_lastrun: float
       speedtest_ping: float
+      site_to_site_enabled: bool
       tx_bytes-r: int
       uptime: int
       wan_ip: string

--- a/pkg/influxunifi/site.go
+++ b/pkg/influxunifi/site.go
@@ -57,6 +57,7 @@ func (u *InfluxUnifi) batchSite(r report, s *unifi.Site) {
 			"remote_user_tx_bytes":     h.RemoteUserTxBytes.Val,
 			"remote_user_rx_packets":   h.RemoteUserRxPackets.Val,
 			"remote_user_tx_packets":   h.RemoteUserTxPackets.Val,
+			"site_to_site_enabled":     h.SiteToSiteEnabled.Val,
 			"num_new_alarms":           s.NumNewAlarms.Val,
 		}
 

--- a/pkg/promunifi/site.go
+++ b/pkg/promunifi/site.go
@@ -31,6 +31,7 @@ type site struct {
 	RemoteUserTxBytes     *prometheus.Desc
 	RemoteUserRxPackets   *prometheus.Desc
 	RemoteUserTxPackets   *prometheus.Desc
+	SiteToSiteEnabled     *prometheus.Desc
 	DPITxPackets          *prometheus.Desc
 	DPIRxPackets          *prometheus.Desc
 	DPITxBytes            *prometheus.Desc
@@ -68,6 +69,7 @@ func descSite(ns string) *site {
 		RemoteUserTxBytes:     nd(ns+"remote_user_transmit_bytes_total", "Remote Users Transmit Bytes", labels, nil),
 		RemoteUserRxPackets:   nd(ns+"remote_user_receive_packets_total", "Remote Users Receive Packets", labels, nil),
 		RemoteUserTxPackets:   nd(ns+"remote_user_transmit_packets_total", "Remote Users Transmit Packets", labels, nil),
+		SiteToSiteEnabled:     nd(ns+"site_to_site_enabled", "Site-to-site VPN enabled (1/0)", labels, nil),
 		DPITxPackets:          nd(ns+"dpi_transmit_packets", "Site DPI Transmit Packets", labelDPI, nil),
 		DPIRxPackets:          nd(ns+"dpi_receive_packets", "Site DPI Receive Packets", labelDPI, nil),
 		DPITxBytes:            nd(ns+"dpi_transmit_bytes", "Site DPI Transmit Bytes", labelDPI, nil),
@@ -160,6 +162,7 @@ func (u *promUnifi) exportSite(r report, s *unifi.Site) {
 				{u.Site.RemoteUserTxBytes, counter, h.RemoteUserTxBytes, labels},
 				{u.Site.RemoteUserRxPackets, counter, h.RemoteUserRxPackets, labels},
 				{u.Site.RemoteUserTxPackets, counter, h.RemoteUserTxPackets, labels},
+				{u.Site.SiteToSiteEnabled, gauge, h.SiteToSiteEnabled.Val, labels},
 			})
 		}
 	}


### PR DESCRIPTION
## Summary

Partial fix for #926. The `site_to_site_enabled` field on the `vpn` subsystem `unifi.Health` entry was never exported to any output backend despite being present in the library struct.

- **InfluxDB** (`pkg/influxunifi/site.go`): added `site_to_site_enabled` to the `subsystems` fields map, using `h.SiteToSiteEnabled.Val` (bool)
- **Prometheus** (`pkg/promunifi/site.go`): added `SiteToSiteEnabled` gauge descriptor initialized with metric name `site_to_site_enabled` and emitted it in the `vpn` case of `exportSite`, passing `h.SiteToSiteEnabled.Val` (bool → 0/1 via the existing collector type switch)
- Updated `integration_test_expectations.yaml` to include the new `site_to_site_enabled: bool` field in the `subsystems` table expectations

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (including `TestInfluxV1Integration`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)