### PR TITLE
fix: reference up.conf.example in brew install steps (#995)

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -548,9 +548,9 @@ brews:
     install: |
       bin.install "unpoller"
       (etc/"unpoller").mkpath
-      etc.install "examples/up.conf" => "unpoller/up.conf.example"
+      etc.install "examples/up.conf.example" => "unpoller/up.conf.example"
     post_install: |
-      etc.install "examples/up.conf" => "unpoller/up.conf"
+      etc.install "examples/up.conf.example" => "unpoller/up.conf"
 
 publishers:
   - name: "packagecloud-publisher"


### PR DESCRIPTION
## Summary
- Fixes #995. `brew install golift/mugs/unpoller` was aborting with `Errno::ENOENT: No such file or directory - examples/up.conf` because the formula's `install`/`post_install` Ruby blocks referenced `examples/up.conf`, while the source tarball only ships `examples/up.conf.example`.
- Updates both `etc.install` source paths in the `brews` block to `examples/up.conf.example`, matching the source path already used by every other section of `.goreleaser.yaml` (archives, dockers, nfpms).
- Destination paths under `#{etc}/unpoller/` are unchanged: the example still lands at `unpoller/up.conf.example` and the seeded active config still lands at `unpoller/up.conf` via `post_install`, so the on-disk layout users (and the `service` block referencing `up.conf`) see is identical.

## Test plan
- [ ] Cut a release (or run goreleaser in dry-run / `--snapshot` mode) and confirm the generated Homebrew formula references `examples/up.conf.example` in both `install` and `post_install`.
- [ ] `brew install golift/mugs/unpoller` completes without the ENOENT error.
- [ ] After install, verify `#{etc}/unpoller/up.conf` and `#{etc}/unpoller/up.conf.example` both exist with the expected example contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)