### PR TITLE
fix(promunifi): avoid descriptor collision on unpoller_device_uptime_seconds

### DIFF
--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -244,7 +244,7 @@ func (u *promUnifi) Run(c poller.Collect) error {
 	u.Topology = descTopology(u.Namespace + "_")
 	u.PortAnomaly = descPortAnomaly(u.Namespace + "_")
 	u.VPNMesh = descVPNMesh(u.Namespace + "_")
-	u.IntegrationDevice = descIntegrationDevice(u.Namespace + "_device_")
+	u.IntegrationDevice = descIntegrationDevice(u.Namespace + "_")
 	u.WANStatus = descWANStatus(u.Namespace + "_")
 	u.PortForward = descPortForward(u.Namespace + "_")
 	u.SSLCertificate = descSSLCertificate(u.Namespace + "_")

--- a/pkg/promunifi/integration_devices.go
+++ b/pkg/promunifi/integration_devices.go
@@ -25,15 +25,15 @@ func descIntegrationDevice(ns string) *integrationDevice {
 	uplinkLabels := []string{"device_id", "uplink_index"}
 
 	return &integrationDevice{
-		CPUUtilizationPct:    prometheus.NewDesc(ns+"cpu_utilization_pct", "Device CPU utilization percentage (Integration/v1)", labels, nil),
-		MemoryUtilizationPct: prometheus.NewDesc(ns+"memory_utilization_pct", "Device memory utilization percentage (Integration/v1)", labels, nil),
-		LoadAverage1Min:      prometheus.NewDesc(ns+"load_average_1min", "Device 1-minute load average (Integration/v1)", labels, nil),
-		LoadAverage5Min:      prometheus.NewDesc(ns+"load_average_5min", "Device 5-minute load average (Integration/v1)", labels, nil),
-		LoadAverage15Min:     prometheus.NewDesc(ns+"load_average_15min", "Device 15-minute load average (Integration/v1)", labels, nil),
-		UptimeSec:            prometheus.NewDesc(ns+"uptime_seconds", "Device uptime in seconds (Integration/v1)", labels, nil),
-		RadioTxRetriesPct:    prometheus.NewDesc(ns+"radio_tx_retries_pct", "Per-radio TX retry percentage (Integration/v1)", radioLabels, nil),
-		UplinkRxRateBps:      prometheus.NewDesc(ns+"uplink_rx_rate_bps", "Per-uplink receive rate in bps (Integration/v1)", uplinkLabels, nil),
-		UplinkTxRateBps:      prometheus.NewDesc(ns+"uplink_tx_rate_bps", "Per-uplink transmit rate in bps (Integration/v1)", uplinkLabels, nil),
+		CPUUtilizationPct:    prometheus.NewDesc(ns+"integration_device_cpu_utilization_pct", "Device CPU utilization percentage (Integration/v1)", labels, nil),
+		MemoryUtilizationPct: prometheus.NewDesc(ns+"integration_device_memory_utilization_pct", "Device memory utilization percentage (Integration/v1)", labels, nil),
+		LoadAverage1Min:      prometheus.NewDesc(ns+"integration_device_load_average_1min", "Device 1-minute load average (Integration/v1)", labels, nil),
+		LoadAverage5Min:      prometheus.NewDesc(ns+"integration_device_load_average_5min", "Device 5-minute load average (Integration/v1)", labels, nil),
+		LoadAverage15Min:     prometheus.NewDesc(ns+"integration_device_load_average_15min", "Device 15-minute load average (Integration/v1)", labels, nil),
+		UptimeSec:            prometheus.NewDesc(ns+"integration_device_uptime_seconds", "Device uptime in seconds (Integration/v1)", labels, nil),
+		RadioTxRetriesPct:    prometheus.NewDesc(ns+"integration_device_radio_tx_retries_pct", "Per-radio TX retry percentage (Integration/v1)", radioLabels, nil),
+		UplinkRxRateBps:      prometheus.NewDesc(ns+"integration_device_uplink_rx_rate_bps", "Per-uplink receive rate in bps (Integration/v1)", uplinkLabels, nil),
+		UplinkTxRateBps:      prometheus.NewDesc(ns+"integration_device_uplink_tx_rate_bps", "Per-uplink transmit rate in bps (Integration/v1)", uplinkLabels, nil),
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #1002 and #1004 — `unpoller:v3.0.0` crashloops on startup whenever the Prometheus output is enabled. Multiple users have reported the same panic across both issues.

`descIntegrationDevice` (added in #999) was registered with namespace prefix `"unpoller_device_"`, producing `unpoller_device_uptime_seconds` with labels `{device_id}` and help `"Device uptime in seconds (Integration/v1)"`. That collides with the existing `descDevice()` metric of the same fully-qualified name, which has labels `{type, site_name, name, source, tag}` and help `"Device Uptime"`. Prometheus `MustRegister` panics on inconsistent descriptors for the same FQDN, so the process never finishes startup:

```
panic: descriptors reported by collector have inconsistent label names or help strings
for the same fully-qualified name, offender is Desc{
  fqName: "unpoller_device_uptime_seconds",
  help: "Device uptime in seconds (Integration/v1)",
  variableLabels: {device_id}
}
```

## Fix

Move the Integration/v1 device metrics under a dedicated `integration_device_` name prefix so they no longer share an FQDN with the legacy device metrics.

The new prefix follows the convention already established by the other Integration/v1 collectors added in #999 — `wifi_broadcast_*`, `acl_rule_*`, `mclag_domain_*`, `pending_device_*`, etc. — where the bare namespace prefix is passed in and the type prefix is baked into each metric name string.

## Affected metric renames

| Before (broken) | After |
|---|---|
| `unpoller_device_uptime_seconds` | `unpoller_integration_device_uptime_seconds` |
| `unpoller_device_cpu_utilization_pct` | `unpoller_integration_device_cpu_utilization_pct` |
| `unpoller_device_memory_utilization_pct` | `unpoller_integration_device_memory_utilization_pct` |
| `unpoller_device_load_average_{1,5,15}min` | `unpoller_integration_device_load_average_{1,5,15}min` |
| `unpoller_device_radio_tx_retries_pct` | `unpoller_integration_device_radio_tx_retries_pct` |
| `unpoller_device_uplink_{rx,tx}_rate_bps` | `unpoller_integration_device_uplink_{rx,tx}_rate_bps` |

No working dashboards/alerts are affected — these metrics never shipped successfully (the panic prevented v3.0.0 from starting at all when Prometheus was enabled), and there are no references to them in `alerts/prometheus/` or anywhere else in the repo.

## Test plan

- [x] `go build ./...` clean
- [x] Verified no other `descXxx(u.Namespace + "_device_")` calls share metric FQDNs with `descDevice()`'s output
- [x] Verified the new `unpoller_integration_device_*` namespace is unused elsewhere in the repo

Fixes #1002
Fixes #1004
