### PR TITLE
feat: add UAP uplink metrics, Prometheus parity for USW/UBB/UDB (#988)

### DIFF
--- a/pkg/datadogunifi/integration_test_expectations.yaml
+++ b/pkg/datadogunifi/integration_test_expectations.yaml
@@ -165,6 +165,13 @@ gauges:
   - unifi.uap.system_uptime
   - unifi.uap.tx_bytes
   - unifi.uap.upgradeable
+  - unifi.uap.uplink_full_duplex
+  - unifi.uap.uplink_max_speed
+  - unifi.uap.uplink_num_port
+  - unifi.uap.uplink_rx_bytes
+  - unifi.uap.uplink_speed
+  - unifi.uap.uplink_tx_bytes
+  - unifi.uap.uplink_up
   - unifi.uap.uptime
   - unifi.uap.user_num_sta
   - unifi.uap_radios.ast_be_xmit

--- a/pkg/datadogunifi/uap.go
+++ b/pkg/datadogunifi/uap.go
@@ -45,15 +45,16 @@ func (u *DatadogUnifi) batchRogueAP(r report, s *unifi.RogueAP) {
 // These points can be passed directly to datadog.
 func (u *DatadogUnifi) batchUAP(r report, s *unifi.UAP) {
 	tags := cleanTags(map[string]string{
-		"mac":       s.Mac,
-		"site_name": s.SiteName,
-		"source":    s.SourceName,
-		"name":      s.Name,
-		"version":   s.Version,
-		"model":     s.Model,
-		"serial":    s.Serial,
-		"type":      s.Type,
-		"ip":        s.IP,
+		"mac":         s.Mac,
+		"site_name":   s.SiteName,
+		"source":      s.SourceName,
+		"name":        s.Name,
+		"version":     s.Version,
+		"model":       s.Model,
+		"serial":      s.Serial,
+		"type":        s.Type,
+		"ip":          s.IP,
+		"uplink_type": s.Uplink.Type,
 	})
 	data := CombineFloat64(
 		u.processUAPstats(s.Stat.Ap),
@@ -70,6 +71,13 @@ func (u *DatadogUnifi) batchUAP(r report, s *unifi.UAP) {
 	data["upgradeable"] = s.Upgradable.Float64()
 	data["adopted"] = s.Adopted.Float64()
 	data["locating"] = s.Locating.Float64()
+	data["uplink_speed"] = s.Uplink.Speed.Val
+	data["uplink_max_speed"] = s.Uplink.MaxSpeed.Val
+	data["uplink_up"] = s.Uplink.Up.Float64()
+	data["uplink_full_duplex"] = s.Uplink.FullDuplex.Float64()
+	data["uplink_num_port"] = float64(s.Uplink.NumPort)
+	data["uplink_rx_bytes"] = s.Uplink.RxBytes.Val
+	data["uplink_tx_bytes"] = s.Uplink.TxBytes.Val
 
 	r.addCount(uapT)
 

--- a/pkg/influxunifi/integration_test_expectations.yaml
+++ b/pkg/influxunifi/integration_test_expectations.yaml
@@ -287,6 +287,14 @@ points:
       temp_sys: float
       tx_bytes: float
       upgradeable: bool
+      uplink_full_duplex: bool
+      uplink_max_speed: float
+      uplink_num_port: int
+      uplink_rx_bytes: float
+      uplink_speed: float
+      uplink_tx_bytes: float
+      uplink_type: string
+      uplink_up: bool
       uptime: float
       user-num_sta: int
   uap_radios:

--- a/pkg/influxunifi/uap.go
+++ b/pkg/influxunifi/uap.go
@@ -67,6 +67,14 @@ func (u *InfluxUnifi) batchUAP(r report, s *unifi.UAP) {
 	fields["guest-num_sta"] = int(s.GuestNumSta.Val)
 	fields["num_sta"] = s.NumSta.Val
 	fields["upgradeable"] = s.Upgradable.Val
+	fields["uplink_type"] = s.Uplink.Type
+	fields["uplink_speed"] = s.Uplink.Speed.Val
+	fields["uplink_max_speed"] = s.Uplink.MaxSpeed.Val
+	fields["uplink_up"] = s.Uplink.Up.Val
+	fields["uplink_full_duplex"] = s.Uplink.FullDuplex.Val
+	fields["uplink_num_port"] = s.Uplink.NumPort
+	fields["uplink_rx_bytes"] = s.Uplink.RxBytes.Val
+	fields["uplink_tx_bytes"] = s.Uplink.TxBytes.Val
 
 	r.addCount(uapT)
 	r.send(&metric{Table: "uap", Tags: tags, Fields: fields})

--- a/pkg/promunifi/uap.go
+++ b/pkg/promunifi/uap.go
@@ -230,10 +230,16 @@ func (u *promUnifi) exportUAP(r report, d *unifi.UAP) {
 		u.exportSYSstats(r, labels, d.SysStats, d.SystemStats)
 		u.exportSTAcount(r, labels, d.UserNumSta, d.GuestNumSta)
 		u.exportRADtable(r, labels, d.RadioTable, d.RadioTableStats)
+		// UAP uplink metrics. The uplink "type" (e.g. "wire" / "wireless")
+		// is encoded as the first label, matching the convention used by
+		// USG/USW/UBB/UDB so dashboards can group by port.
+		labelUL := append([]string{d.Uplink.Type}, labels[1:]...)
 		r.send([]*metric{
 			{u.Device.Info, gauge, 1.0, append(baseLabels, infoLabels...)},
 			{u.Device.Uptime, gauge, d.Uptime, labels},
 			{u.Device.Upgradeable, gauge, d.Upgradable.Val, labels},
+			{u.USG.UplinkSpeed, gauge, d.Uplink.Speed, labelUL},
+			{u.USG.UplinkMaxSpeed, gauge, d.Uplink.MaxSpeed, labelUL},
 		})
 	})
 }

--- a/pkg/promunifi/ubb.go
+++ b/pkg/promunifi/ubb.go
@@ -37,6 +37,10 @@ func (u *promUnifi) exportUBB(r report, d *unifi.UBB) {
 			u.exportSYSstats(r, labels, *d.SysStats, *d.SystemStats)
 		}
 
+		if d.Uplink != nil {
+			u.exportDeviceUplink(r, labels, *d.Uplink)
+		}
+
 		// Device info, uptime, and temperature
 		r.send([]*metric{
 			{u.Device.Info, gauge, 1.0, append(baseLabels, infoLabels...)},

--- a/pkg/promunifi/udb.go
+++ b/pkg/promunifi/udb.go
@@ -31,6 +31,7 @@ func (u *promUnifi) exportUDB(r report, d *unifi.UDB) {
 		u.exportBYTstats(r, labels, d.TxBytes, d.RxBytes)
 		u.exportSYSstats(r, labels, d.SysStats, d.SystemStats)
 		u.exportSTAcount(r, labels, d.UserNumSta, d.GuestNumSta)
+		u.exportDeviceUplink(r, labels, d.Uplink)
 
 		r.send([]*metric{
 			{u.Device.Info, gauge, 1.0, append(baseLabels, infoLabels...)},

--- a/pkg/promunifi/usg.go
+++ b/pkg/promunifi/usg.go
@@ -117,6 +117,25 @@ func (u *promUnifi) exportUSG(r report, d *unifi.USG) {
 	})
 }
 
+// exportDeviceUplink emits the shared uplink metrics for any device that
+// carries a unifi.Uplink (USW/UBB/UDB). The uplink port name is used as the
+// first label, matching the convention used by exportUSGstats.
+func (u *promUnifi) exportDeviceUplink(r report, labels []string, ul unifi.Uplink) {
+	port := ul.Name
+	if port == "" {
+		port = "uplink"
+	}
+
+	labelUL := []string{port, labels[1], labels[2], labels[3], labels[4]}
+
+	r.send([]*metric{
+		{u.USG.UplinkLatency, gauge, ul.Latency.Val / 1000, labelUL},
+		{u.USG.UplinkSpeed, gauge, ul.Speed, labelUL},
+		{u.USG.UplinkMaxSpeed, gauge, ul.MaxSpeed, labelUL},
+		{u.USG.UplinkUptime, gauge, ul.Uptime, labelUL},
+	})
+}
+
 // Gateway Stats.
 func (u *promUnifi) exportUSGstats(r report, labels []string, gw *unifi.Gw, st unifi.SpeedtestStatus, ul unifi.Uplink) {
 	var sourceInterface string

--- a/pkg/promunifi/usw.go
+++ b/pkg/promunifi/usw.go
@@ -129,6 +129,7 @@ func (u *promUnifi) exportUSW(r report, d *unifi.USW) {
 		u.exportBYTstats(r, labels, d.TxBytes, d.RxBytes)
 		u.exportSYSstats(r, labels, d.SysStats, d.SystemStats)
 		u.exportSTAcount(r, labels, d.UserNumSta, d.GuestNumSta)
+		u.exportDeviceUplink(r, labels, d.Uplink)
 		r.send([]*metric{
 			{u.Device.Info, gauge, 1.0, append(baseLabels, infoLabels...)},
 			{u.Device.Uptime, gauge, d.Uptime, labels},


### PR DESCRIPTION
## Summary

- Adds uplink metrics for UniFi access points (UAP) across all three output plugins (influxunifi, datadogunifi, promunifi). UAPs previously had zero uplink coverage; closes #988.
- Brings Prometheus to parity with Influx/Datadog by emitting uplink metrics for USW, UBB, and UDB (previously only USG/UDM/UXG were covered in promunifi).
- Introduces `exportDeviceUplink` helper in `pkg/promunifi/usg.go` that reuses the existing `unpoller_device_uplink_*` descriptors so we avoid the descriptor-collision class of bug fixed in c48b9917.

## What the issue asked for

#988 wants visibility into AP uplink medium (lan vs wlan) and link speed (10/100/1000/...) so users can detect when an AP silently downgrades to fast ethernet. The UniFi controller exposes this as `data[x].uplink.max_speed` and `data[x].uplink.type`, and both fields are already in the unpoller `unifi.UAP` struct — they just weren't exported anywhere.

## Fields added (per output)

**InfluxDB (`uap` measurement)** and **Datadog (`unpoller.uap.*`):**
- `uplink_type` (`wire` / `wireless`) — Datadog as a tag, Influx as a string field
- `uplink_speed`, `uplink_max_speed`
- `uplink_up`, `uplink_full_duplex`
- `uplink_num_port`, `uplink_rx_bytes`, `uplink_tx_bytes`

**Prometheus (`unpoller_device_uplink_*`):**
- `unpoller_device_uplink_speed_mbps{port="<wire|wireless>", site_name=..., name=..., source=..., tag=...}`
- `unpoller_device_uplink_max_speed_mbps{...}`

The `port` label encodes wire-vs-wireless for UAPs (matching what the issue asks for) and the uplink port name for USG/USW/UBB/UDB. UAP's `Uplink` is an anonymous struct without `Latency`/`Uptime`, so those two metrics aren't emitted for UAPs.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `golangci-lint run` clean
- [ ] Manual: point at a controller and confirm `unpoller_device_uplink_max_speed_mbps{name="<ap-name>",port="wire"}` appears
- [ ] Manual: confirm Influx `uap` measurement contains the new `uplink_*` fields
- [ ] Manual: confirm Datadog reports `unpoller.uap.uplink_max_speed` with `uplink_type:wire` tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)