### PR TITLE
chore(deps): upgrade unifi to v5.28.0 (fixes #997)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus/common v0.67.5
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	github.com/unpoller/unifi/v5 v5.27.0
+	github.com/unpoller/unifi/v5 v5.28.0
 	go.opentelemetry.io/otel v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.43.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.43.0

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/unpoller/unifi/v5 v5.27.0 h1:UK8KN0GHhjo7zM9rXmUkt9RTTYqnJt/Y7uwPCeq4mUs=
-github.com/unpoller/unifi/v5 v5.27.0/go.mod h1:G1PKfGQsflTd4nVgoLFUkvce+wcdd8tu5ICS42X3MJY=
+github.com/unpoller/unifi/v5 v5.28.0 h1:8pZJEH4Z3+QjFQZDxW4QmixI5zr/lGKd4s6LYB9+Vt4=
+github.com/unpoller/unifi/v5 v5.28.0/go.mod h1:G1PKfGQsflTd4nVgoLFUkvce+wcdd8tu5ICS42X3MJY=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=


### PR DESCRIPTION
## Summary
- Bump `github.com/unpoller/unifi/v5` from v5.27.0 to v5.28.0
- Picks up unpoller/unifi#220, which decompresses gzip response bodies returned by the Site Manager proxy when `Content-Encoding` is stripped — the root cause of the `\x1f` JSON parse error reported in #997 for Official UniFi Cloud Hosted consoles.

## Test plan
- [x] `go mod tidy`
- [x] `go build ./...`
- [x] `go test ./...`
- [ ] Verified by an affected user against a Cloud Hosted console (`*.unifi-hosting.ui.com`) using `remote: true` + Site Manager `api_key`

Closes #997