### PR TITLE
feat(promunifi): export DOCSIS CI state metrics for UCI devices

### DIFF
--- a/pkg/promunifi/uci.go
+++ b/pkg/promunifi/uci.go
@@ -37,5 +37,32 @@ func (u *promUnifi) exportUCI(r report, d *unifi.UCI) {
 			{u.Device.Info, gauge, 1.0, append(baseLabels, infoLabels...)},
 			{u.Device.Uptime, gauge, d.Uptime, labels},
 		})
+
+		// DOCSIS / Cable Internet state.
+		//
+		// The controller exposes a top-level `internet` boolean on UCI devices,
+		// but it is not a reliable WAN-reachability signal — it stays false
+		// even when the cable link is fully up and traffic is flowing. The
+		// UCI is a cable bridge with no independent internet-reachability
+		// check; real WAN health lives on the upstream gateway (e.g. UDM
+		// `wan1.up`).
+		//
+		// Instead, derive an operational gauge from the DOCSIS CI state,
+		// which IS reported reliably by the controller. The full state
+		// string is also exposed as a label on `*_ci_state_info`.
+		if d.CiStateTable != nil {
+			r.send([]*metric{
+				{
+					u.Device.CiStateOperational, gauge,
+					d.CiStateTable.CIState == "Operational",
+					labels,
+				},
+				{
+					u.Device.CiStateInfo, gauge, 1.0,
+					append(labels, d.CiStateTable.CIState, d.CiStateTable.CISwDlStatus,
+						d.CiStateTable.CIMac, d.CiStateTable.CIVersion, d.CiStateTable.CIMode),
+				},
+			})
+		}
 	})
 }

--- a/pkg/promunifi/udm.go
+++ b/pkg/promunifi/udm.go
@@ -32,6 +32,8 @@ type unifiDevice struct {
 	CPU                      *prometheus.Desc
 	Mem                      *prometheus.Desc
 	Upgradeable              *prometheus.Desc
+	CiStateOperational       *prometheus.Desc // uci only
+	CiStateInfo              *prometheus.Desc // uci only
 }
 
 func descDevice(ns string) *unifiDevice {
@@ -66,6 +68,12 @@ func descDevice(ns string) *unifiDevice {
 		CPU:                      prometheus.NewDesc(ns+"cpu_utilization_ratio", "System CPU % Utilized", append(labels, "tag"), nil),
 		Mem:                      prometheus.NewDesc(ns+"memory_utilization_ratio", "System Memory % Utilized", append(labels, "tag"), nil),
 		Upgradeable:              prometheus.NewDesc(ns+"upgradable", "Upgrade-able", append(labels, "tag"), nil),
+		CiStateOperational: prometheus.NewDesc(ns+"ci_state_operational",
+			"DOCSIS Cable Internet Operational State (1=Operational, 0=other). UCI devices only.",
+			append(labels, "tag"), nil),
+		CiStateInfo: prometheus.NewDesc(ns+"ci_state_info",
+			"DOCSIS CI State Information. UCI devices only.",
+			append(append(labels, "tag"), "ci_state", "ci_sw_dl_status", "ci_mac", "ci_version", "ci_mode"), nil),
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds two new Prometheus metrics for UCI (UniFi Cable Internet) devices, derived from the controller's `ci_state_table`:

- **`unpoller_device_ci_state_operational`** (gauge): `1` if DOCSIS CI state is `Operational`, else `0`. Suitable for alerting on cable link health.
- **`unpoller_device_ci_state_info`** (info-style gauge, always `1`): exposes the full DOCSIS CI state table as labels for diagnostic dashboards: `ci_state`, `ci_sw_dl_status`, `ci_mac`, `ci_version`, `ci_mode`.

The existing UCI exporter (`pkg/promunifi/uci.go`) currently emits only the generic device stats (bytes, sys stats, uptime, info) — no DOCSIS-specific signals. This PR fills that gap with a small, purely additive change.


## Diff size

35 insertions across 2 files — purely additive, no existing behavior changes:
- `pkg/promunifi/udm.go`: 2 new descriptor fields on the shared `unifiDevice` struct + their `NewDesc` initializations
- `pkg/promunifi/uci.go`: one new `if d.CiStateTable != nil` block in `exportUCI()`

## Test plan

- [x] Builds clean against current `master`
- [x] Verified on a live UCI cable modem in Operational state (`ci_mode=\"D3.1\"`) — both metrics scraped correctly by Prometheus
- [x] Confirmed `ci_state_operational` reflects `ci_state == \"Operational\"` correctly
- [ ] CI