### PR TITLE
feat(promunifi): add mac label to per-VAP and per-radio metrics

### DIFF
--- a/pkg/promunifi/uap.go
+++ b/pkg/promunifi/uap.go
@@ -112,8 +112,8 @@ func descRogueAP(ns string) *rogueap {
 
 func descUAP(ns string) *uap { // nolint: funlen
 	labelA := []string{"stat", "site_name", "name", "source", "tag"} // stat + labels[1:]
-	labelV := []string{"vap_name", "bssid", "radio", "radio_name", "essid", "usage", "site_name", "name", "source", "tag"}
-	labelR := []string{"radio_name", "radio", "site_name", "name", "source", "tag"}
+	labelV := []string{"vap_name", "bssid", "radio", "radio_name", "essid", "usage", "mac", "site_name", "name", "source", "tag"}
+	labelR := []string{"radio_name", "radio", "mac", "site_name", "name", "source", "tag"}
 	nd := prometheus.NewDesc
 
 	return &uap{
@@ -224,12 +224,12 @@ func (u *promUnifi) exportUAP(r report, d *unifi.UAP) {
 		infoLabels := append(baseInfoLabels, tag)
 
 		u.exportUAPstats(r, labels, d.Stat.Ap, d.BytesD, d.TxBytesD, d.RxBytesD, d.BytesR)
-		u.exportVAPtable(r, labels, d.VapTable)
+		u.exportVAPtable(r, labels, d.VapTable, d.Mac)
 		u.exportPRTtable(r, labels, d.PortTable)
 		u.exportBYTstats(r, labels, d.TxBytes, d.RxBytes)
 		u.exportSYSstats(r, labels, d.SysStats, d.SystemStats)
 		u.exportSTAcount(r, labels, d.UserNumSta, d.GuestNumSta)
-		u.exportRADtable(r, labels, d.RadioTable, d.RadioTableStats)
+		u.exportRADtable(r, labels, d.RadioTable, d.RadioTableStats, d.Mac)
 		// UAP uplink metrics. The uplink "type" (e.g. "wire" / "wireless")
 		// is encoded as the first label, matching the convention used by
 		// USG/USW/UBB/UDB so dashboards can group by port.
@@ -292,14 +292,14 @@ func (u *promUnifi) exportUAPstats(r report, labels []string, ap *unifi.Ap, byte
 }
 
 // UAP VAP Table.
-func (u *promUnifi) exportVAPtable(r report, labels []string, vt unifi.VapTable) {
+func (u *promUnifi) exportVAPtable(r report, labels []string, vt unifi.VapTable, mac string) {
 	// vap table stats
 	for _, v := range vt {
 		if !v.Up.Val {
 			continue
 		}
 
-		labelV := []string{v.Name, v.Bssid, v.Radio, v.RadioName, v.Essid, v.Usage, labels[1], labels[2], labels[3], labels[4]}
+		labelV := []string{v.Name, v.Bssid, v.Radio, v.RadioName, v.Essid, v.Usage, mac, labels[1], labels[2], labels[3], labels[4]}
 		r.send([]*metric{
 			{u.UAP.VAPCcq, gauge, float64(v.Ccq) / 1000.0, labelV},
 			{u.UAP.VAPMacFilterRejections, counter, v.MacFilterRejections, labelV},
@@ -343,10 +343,10 @@ func (u *promUnifi) exportVAPtable(r report, labels []string, vt unifi.VapTable)
 }
 
 // UAP Radio Table.
-func (u *promUnifi) exportRADtable(r report, labels []string, rt unifi.RadioTable, rts unifi.RadioTableStats) {
+func (u *promUnifi) exportRADtable(r report, labels []string, rt unifi.RadioTable, rts unifi.RadioTableStats, mac string) {
 	// radio table
 	for _, p := range rt {
-		labelR := []string{p.Name, p.Radio, labels[1], labels[2], labels[3], labels[4]}
+		labelR := []string{p.Name, p.Radio, mac, labels[1], labels[2], labels[3], labels[4]}
 		labelRUser := append(labelR, "user")
 		labelRGuest := append(labelR, "guest")
 

--- a/pkg/promunifi/ubb.go
+++ b/pkg/promunifi/ubb.go
@@ -25,10 +25,10 @@ func (u *promUnifi) exportUBB(r report, d *unifi.UBB) {
 		u.exportUBBstats(r, labels, d.Stat)
 
 		// Export VAP table (Virtual Access Point table - wireless interface stats)
-		u.exportVAPtable(r, labels, d.VapTable)
+		u.exportVAPtable(r, labels, d.VapTable, d.Mac)
 
 		// Export Radio tables (includes 5GHz wifi0 and 60GHz terra2/ad radios)
-		u.exportRADtable(r, labels, d.RadioTable, d.RadioTableStats)
+		u.exportRADtable(r, labels, d.RadioTable, d.RadioTableStats, d.Mac)
 
 		// Shared device stats
 		u.exportBYTstats(r, labels, d.TxBytes, d.RxBytes)

--- a/pkg/promunifi/udb.go
+++ b/pkg/promunifi/udb.go
@@ -24,8 +24,8 @@ func (u *promUnifi) exportUDB(r report, d *unifi.UDB) {
 		u.exportPRTtable(r, labels, d.PortTable)
 
 		// Export wireless stats (reuse UAP functions)
-		u.exportVAPtable(r, labels, d.VapTable)
-		u.exportRADtable(r, labels, d.RadioTable, d.RadioTableStats)
+		u.exportVAPtable(r, labels, d.VapTable, d.Mac)
+		u.exportRADtable(r, labels, d.RadioTable, d.RadioTableStats, d.Mac)
 
 		// Common device stats
 		u.exportBYTstats(r, labels, d.TxBytes, d.RxBytes)

--- a/pkg/promunifi/udm.go
+++ b/pkg/promunifi/udm.go
@@ -130,8 +130,8 @@ func (u *promUnifi) exportUDM(r report, d *unifi.UDM) {
 			tag := tagLabels[0]
 			labels := append(baseLabels, tag)
 			u.exportUAPstats(r, labels, d.Stat.Ap, d.BytesD, d.TxBytesD, d.RxBytesD, d.BytesR)
-			u.exportVAPtable(r, labels, *d.VapTable)
-			u.exportRADtable(r, labels, *d.RadioTable, *d.RadioTableStats)
+			u.exportVAPtable(r, labels, *d.VapTable, d.Mac)
+			u.exportRADtable(r, labels, *d.RadioTable, *d.RadioTableStats, d.Mac)
 		})
 	}
 }


### PR DESCRIPTION
## Problem

`unifi_device_vap_*` and `unifi_device_radio_*` currently expose only `(site_name, name, source)` as per-device identifying labels. None of these is a stable primary key for joining:

- `name` is user-editable in the UniFi controller
- `source` is the controller hostname (same for every device behind a given controller)
- `site_name` only narrows the search, not unique per device

This makes it hard to join VAP/radio metrics against `unifi_device_info` (which already carries `mac`, `serial`, etc.) or against external data sources keyed on MAC.

## Change

Thread `d.Mac` (already available on the parent `UAP`/`UDM`/`UDB`/`UBB` struct) through `exportVAPtable` and `exportRADtable`, and add it as a `mac` label on every series those two functions emit.

Resulting label sets:

- per-VAP (`unifi_device_vap_*`): `vap_name, bssid, radio, radio_name, essid, usage, mac, site_name, name, source, tag`
- per-radio (`unifi_device_radio_*`): `radio_name, radio, mac, site_name, name, source, tag`

`mac` is positioned before `site_name`, matching the existing label ordering used by `descRogueAP`.

## Scope

- Touches only `pkg/promunifi/{uap,udm,udb,ubb}.go` — the four call sites of `exportVAPtable`/`exportRADtable`.
- AP-level stat metrics (`stat_*`, using `labelA`) are intentionally **not** changed — they aggregate user/guest/all and weren't part of the join problem; leaving them unchanged keeps cardinality stable.
- No changes to other exporters (influx, datadog, loki, otel) — those use a different label model.

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./...` — all packages pass

## Compatibility note

This adds a new label to existing metrics. Dashboards/recording rules that use `by (...)` or `without (...)` aggregations without listing `mac` will continue to work; rules that match on full label sets via `==` may need to ignore the new label.