### PR TITLE
feat: implement 1x_identity support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus/common v0.69.0
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	github.com/unpoller/unifi/v5 v5.28.1
+	github.com/unpoller/unifi/v5 v5.28.2-0.20260710223336-0de412a69b2f
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0
@@ -36,7 +36,7 @@ require (
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/otel/trace v1.44.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect

--- a/go.sum
+++ b/go.sum
@@ -89,6 +89,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/unpoller/unifi/v5 v5.28.1 h1:vHvMqYB1rVmJJgJoCY7xQ9NAxxhjrm4gSLlieJTEPLA=
 github.com/unpoller/unifi/v5 v5.28.1/go.mod h1:G1PKfGQsflTd4nVgoLFUkvce+wcdd8tu5ICS42X3MJY=
+github.com/unpoller/unifi/v5 v5.28.2-0.20260710223336-0de412a69b2f h1:g7smcxdkcxdoFPU4SD1CmE1rEmuBILPcn10z+Dw5qBA=
+github.com/unpoller/unifi/v5 v5.28.2-0.20260710223336-0de412a69b2f/go.mod h1:yg2J6B08FTh3NhLEXEupgSlGBIM0+BlY2QkTfnKwD80=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=
@@ -124,6 +126,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
 golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=

--- a/pkg/datadogunifi/clients.go
+++ b/pkg/datadogunifi/clients.go
@@ -36,6 +36,7 @@ func (u *DatadogUnifi) batchClient(r report, s *unifi.Client) { // nolint: funle
 		"essid":        s.Essid,
 		"bssid":        s.Bssid,
 		"ip":           s.IP,
+		"1x_identity":  s.Identity1x,
 	}
 
 	powerSaveEnabled := 0.0

--- a/pkg/influxunifi/clients.go
+++ b/pkg/influxunifi/clients.go
@@ -32,6 +32,7 @@ func (u *InfluxUnifi) batchClient(r report, s *unifi.Client) { // nolint: funlen
 		"use_fixedip": s.UseFixedIP.Txt,
 		"channel":     s.Channel.Txt,
 		"vlan":        s.Vlan.Txt,
+		"1x_identity": s.Identity1x,
 	}
 
 	fields := map[string]any{

--- a/pkg/influxunifi/integration_test_expectations.yaml
+++ b/pkg/influxunifi/integration_test_expectations.yaml
@@ -16,6 +16,7 @@ points:
       tx_packets: int
   clients:
     tags:
+      - 1x_identity
       - channel
       - dev_cat
       - dev_family

--- a/pkg/inputunifi/updateweb.go
+++ b/pkg/inputunifi/updateweb.go
@@ -143,6 +143,7 @@ func formatClients(c *Controller, clients []*unifi.Client) (d webserver.Clients)
 			IP:         client.IP,
 			Type:       clientType,
 			DeviceMAC:  deviceMAC,
+			Identity1x: client.Identity1x,
 			Rx:         client.RxBytes.Int64(),
 			Tx:         client.TxBytes.Int64(),
 			Since:      time.Unix(client.FirstSeen.Int64(), 0),

--- a/pkg/otelunifi/report.go
+++ b/pkg/otelunifi/report.go
@@ -127,6 +127,7 @@ func (u *OtelOutput) exportClients(ctx context.Context, meter metric.Meter, m *p
 			attribute.String("network", c.Network),
 			attribute.String("ap_name", c.ApName),
 			attribute.String("sw_name", c.SwName),
+			attribute.String("identity", c.Identity1x),
 			attribute.Bool("wired", c.IsWired.Val),
 		)
 

--- a/pkg/promunifi/clients.go
+++ b/pkg/promunifi/clients.go
@@ -45,7 +45,7 @@ type uclient struct {
 func descClient(ns string) *uclient {
 	labels := []string{
 		"name", "mac", "site_name", "gw_name", "sw_name", "vlan",
-		"ip", "oui", "network", "sw_port", "ap_name", "source", "wired",
+		"ip", "oui", "network", "sw_port", "ap_name", "source", "identity", "wired",
 	}
 	labelW := append([]string{"radio_name", "radio", "radio_proto", "channel", "essid", "bssid", "radio_desc"}, labels...)
 	labelDPI := []string{"name", "mac", "site_name", "source", "category", "application"}
@@ -111,7 +111,7 @@ func (u *promUnifi) exportClientDPI(r report, v any, appTotal, catTotal totalsDP
 func (u *promUnifi) exportClient(r report, c *unifi.Client) {
 	labels := []string{
 		c.Name, c.Mac, c.SiteName, c.GwName, c.SwName, c.Vlan.Txt,
-		c.IP, c.Oui, c.Network, c.SwPort.Txt, c.ApName, c.SourceName, "",
+		c.IP, c.Oui, c.Network, c.SwPort.Txt, c.ApName, c.SourceName, c.Identity1x, "",
 	}
 	labelW := append([]string{
 		c.RadioName, c.Radio, c.RadioProto, c.Channel.Txt, c.Essid, c.Bssid, c.RadioDescription,

--- a/pkg/webserver/plugins_types.go
+++ b/pkg/webserver/plugins_types.go
@@ -133,6 +133,7 @@ type Client struct {
 	IP         string    `json:"ip"`
 	Type       string    `json:"type"`
 	DeviceMAC  string    `json:"device_mac"`
+	Identity1x string    `json:"1x_identity"`
 	Since      time.Time `json:"since"`
 	Last       time.Time `json:"last"`
 }


### PR DESCRIPTION
This implements https://github.com/unpoller/unpoller/issues/959.

Right now the dependency update is not part of the MR, I will update the dependency once https://github.com/unpoller/unifi/pull/226 is merged.

One thing I'm unsure about: If you do not use 802.1x authentication the label is empty. I don't know if this is the best way to handle it. Right now it seems unpoller also outputs other empty labels by default.