### PR TITLE
feat: add manual tag-creation workflow using git-semver

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,47 @@
+name: Create Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version component to bump'
+        required: true
+        default: 'minor'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - run: git fetch --force --tags
+      - uses: actions/setup-go@v6
+        with:
+          go-version: 'stable'
+          cache: true
+      - name: Install git-semver
+        run: go install github.com/mdomke/git-semver/v6@latest
+      - name: Compute next version
+        id: semver
+        env:
+          BUMP: ${{ inputs.bump }}
+        run: |
+          NEXT_VERSION=$(git-semver -target "$BUMP" -prefix v)
+          echo "version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "${{ steps.semver.outputs.version }}" -m "Release ${{ steps.semver.outputs.version }}"
+          git push origin "${{ steps.semver.outputs.version }}"
+      - name: Summary
+        run: echo "Created tag ${{ steps.semver.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/tag.yml`, a `workflow_dispatch` workflow to manually create a new release tag.
- Uses [`mdomke/git-semver`](https://github.com/mdomke/git-semver) to compute the next version, with a `bump` input (`patch`, `minor` [default], `major`).
- Pushes the resulting `v*` tag, which triggers the existing `release.yml` workflow.

## Test plan
- [ ] Run the workflow manually via Actions tab with each `bump` option and confirm the correct tag is created and pushed
- [ ] Confirm the `release.yml` workflow fires off the newly pushed tag