### PR TITLE
fix: dispatch release workflow after creating a tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     # run only against tags
     tags:
       - '*'
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: write
+  actions: write
 
 jobs:
   tag:
@@ -43,5 +44,12 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "${{ steps.semver.outputs.version }}" -m "Release ${{ steps.semver.outputs.version }}"
           git push origin "${{ steps.semver.outputs.version }}"
+      - name: Trigger release workflow
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.semver.outputs.version }}
+        run: gh workflow run release.yml --ref "$TAG"
       - name: Summary
-        run: echo "Created tag ${{ steps.semver.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+        env:
+          TAG: ${{ steps.semver.outputs.version }}
+        run: echo "Created tag $TAG" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Tags pushed with the default `GITHUB_TOKEN` don't trigger other workflows' `push` events, so `release.yml` never ran after `tag.yml` created a new tag.
- Add `workflow_dispatch` trigger to `release.yml`.
- Have `tag.yml` explicitly run `gh workflow run release.yml --ref <tag>` right after pushing the tag (grant it `actions: write`).

## Test plan
- [ ] Manually run the "Create Tag" workflow and confirm the "Release" workflow starts automatically against the new tag
- [ ] Confirm the release run checks out the correct tag and `github.ref_name` resolves to the tag (used in the helm-chart-update dispatch payload)