### PR TITLE
feat(inputunifi): add save_speedtest toggle for the WAN speed test poll

### DIFF
--- a/examples/remote_api_example.conf
+++ b/examples/remote_api_example.conf
@@ -25,6 +25,7 @@ save_anomalies = true
 save_ids = true
 save_traffic = true
 save_rogue = true
+save_speedtest = true
 save_syslog = true
 save_protect_logs = false
 verify_ssl = true

--- a/examples/remote_api_example.json
+++ b/examples/remote_api_example.json
@@ -15,6 +15,7 @@
       "save_ids": true,
       "save_traffic": true,
       "save_rogue": true,
+      "save_speedtest": true,
       "save_syslog": true,
       "save_protect_logs": false,
       "verify_ssl": true

--- a/examples/remote_api_example.yaml
+++ b/examples/remote_api_example.yaml
@@ -28,6 +28,7 @@ unifi:
     save_ids: true
     save_traffic: true
     save_rogue: true
+    save_speedtest: true
     save_syslog: true
     save_protect_logs: false
     # Remote API requires SSL verification

--- a/examples/up.conf.example
+++ b/examples/up.conf.example
@@ -226,6 +226,11 @@
   ## This saves neighboring access point metrics in a dedicated table or namespace.
   save_rogue = false
 
+  ## WAN speed test results, polled from the controller's aggregated-dashboard
+  ## endpoint. Enabled by default. Set to false to skip that request entirely if
+  ## your controller misbehaves on it or you simply don't want the metrics.
+  save_speedtest = true
+
   # If your UniFi controller has a valid SSL certificate (like lets encrypt),
   # you can enable this option to validate it. Otherwise, any SSL certificate is
   # valid. If you don't know if you have a valid SSL cert, then you don't have one.
@@ -259,5 +264,6 @@
 #  save_dpi    = false
 #  save_traffic = false
 #  save_rogue  = false
+#  save_speedtest = true
 #  verify_ssl  = false
 #  ssl_cert_paths = []

--- a/pkg/inputunifi/collector.go
+++ b/pkg/inputunifi/collector.go
@@ -190,11 +190,13 @@ func (u *InputUnifi) pollController(c *Controller) (*poller.Metrics, error) {
 		len(m.Devices.USWs), len(m.Devices.UDMs))
 
 	// Get speed test results for all WANs
-	if m.SpeedTests, err = c.Unifi.GetSpeedTests(sites, historySeconds); err != nil {
-		// Don't fail collection if speed tests fail - older controllers may not have this endpoint
-		u.LogDebugf("unifi.GetSpeedTests(%s): %v (continuing)", c.URL, err)
-	} else {
-		u.LogDebugf("Found %d SpeedTests entries", len(m.SpeedTests))
+	if c.SaveSpeedTest != nil && *c.SaveSpeedTest {
+		if m.SpeedTests, err = c.Unifi.GetSpeedTests(sites, historySeconds); err != nil {
+			// Don't fail collection if speed tests fail - older controllers may not have this endpoint
+			u.LogDebugf("unifi.GetSpeedTests(%s): %v (continuing)", c.URL, err)
+		} else {
+			u.LogDebugf("Found %d SpeedTests entries", len(m.SpeedTests))
+		}
 	}
 
 	// Get DHCP leases with associations.

--- a/pkg/inputunifi/input.go
+++ b/pkg/inputunifi/input.go
@@ -48,6 +48,7 @@ type Controller struct {
 	SaveDPI                 *bool         `json:"save_dpi"                   toml:"save_dpi"                   xml:"save_dpi"                   yaml:"save_dpi"`
 	SaveTraffic             *bool         `json:"save_traffic"               toml:"save_traffic"               xml:"save_traffic"               yaml:"save_traffic"`
 	SaveRogue               *bool         `json:"save_rogue"                 toml:"save_rogue"                 xml:"save_rogue"                 yaml:"save_rogue"`
+	SaveSpeedTest           *bool         `json:"save_speedtest"             toml:"save_speedtest"             xml:"save_speedtest"             yaml:"save_speedtest"`
 	HashPII                 *bool         `json:"hash_pii"                   toml:"hash_pii"                   xml:"hash_pii"                   yaml:"hash_pii"`
 	DropPII                 *bool         `json:"drop_pii"                   toml:"drop_pii"                   xml:"drop_pii"                   yaml:"drop_pii"`
 	SaveSites               *bool         `json:"save_sites"                 toml:"save_sites"                 xml:"save_sites"                 yaml:"save_sites"`
@@ -315,6 +316,12 @@ func (u *InputUnifi) setDefaults(c *Controller) { //nolint:cyclop
 		c.SaveRogue = &f
 	}
 
+	// Defaults to true: the speed test poll has always run unconditionally,
+	// so an explicit opt-out keeps existing setups behaving the same.
+	if c.SaveSpeedTest == nil {
+		c.SaveSpeedTest = &t
+	}
+
 	if c.SaveIDs == nil {
 		c.SaveIDs = &f
 	}
@@ -431,6 +438,10 @@ func (u *InputUnifi) setControllerDefaults(c *Controller) *Controller { //nolint
 
 	if c.SaveRogue == nil {
 		c.SaveRogue = u.Default.SaveRogue
+	}
+
+	if c.SaveSpeedTest == nil {
+		c.SaveSpeedTest = u.Default.SaveSpeedTest
 	}
 
 	if c.SaveEvents == nil {

--- a/pkg/inputunifi/interface.go
+++ b/pkg/inputunifi/interface.go
@@ -190,6 +190,7 @@ func (u *InputUnifi) logController(c *Controller) {
 	u.Logf("   => Save Alarms %v / Anomalies %v / Protect Logs %v (thumbnails: %v)", *c.SaveAlarms, *c.SaveAnomal, *c.SaveProtectLogs, *c.ProtectThumbnails)
 	u.Logf("   => Save Rogue APs: %v", *c.SaveRogue)
 	u.Logf("   => Save Traffic %v", *c.SaveTraffic)
+	u.Logf("   => Save Speed Tests: %v", *c.SaveSpeedTest)
 }
 
 // Events allows you to pull only events (and IDs) from the UniFi Controller.

--- a/pkg/inputunifi/remote.go
+++ b/pkg/inputunifi/remote.go
@@ -155,6 +155,10 @@ func (u *InputUnifi) discoverRemoteControllers(apiKey string) ([]*Controller, er
 			controller.SaveRogue = &f
 		}
 
+		if controller.SaveSpeedTest == nil {
+			controller.SaveSpeedTest = &t
+		}
+
 		if controller.SaveSyslog == nil {
 			controller.SaveSyslog = &f
 		}

--- a/pkg/inputunifi/updateweb.go
+++ b/pkg/inputunifi/updateweb.go
@@ -74,6 +74,7 @@ func formatControllers(controllers []*Controller) []*Controller {
 			SaveAnomal:      c.SaveAnomal,
 			SaveAlarms:      c.SaveAlarms,
 			SaveRogue:       c.SaveRogue,
+			SaveSpeedTest:   c.SaveSpeedTest,
 			SaveEvents:      c.SaveEvents,
 			SaveSyslog:      c.SaveSyslog,
 			SaveProtectLogs: c.SaveProtectLogs,


### PR DESCRIPTION
## What

Adds a `save_speedtest` toggle for the WAN Site Speed Test poll (the `v2/api/site/<site>/aggregated-dashboard` request), matching the existing `save_*` flags.

`GetSpeedTests` has always been called unconditionally in `pollController`, so there is currently no way to skip that request. #1030 asks for exactly this as a workaround (question 1: *"Is there a config flag to disable the Site Speed Test / aggregated-dashboard poll?"*), and it also helps anyone who simply doesn't want the metrics or wants one fewer API call per cycle.

## Behaviour

Defaults to **true**, so nothing changes unless you opt out. The default is set in all three paths that initialise controller flags:

- `setDefaults` (local defaults)
- `setControllerDefaults` (per-controller inheritance from `[unifi.defaults]`)
- `discoverRemoteControllers` (remote API discovery)

Config, following the existing pattern:

```toml
[unifi.defaults]
  save_speedtest = false
```

Or via environment: `UP_UNIFI_DEFAULT_SAVE_SPEEDTEST=false`

## Changes

- `pkg/inputunifi/input.go` — `SaveSpeedTest *bool` field plus both default paths
- `pkg/inputunifi/remote.go` — default for remote-discovered controllers
- `pkg/inputunifi/collector.go` — gate around the `GetSpeedTests` call
- `pkg/inputunifi/interface.go` — startup log line
- `pkg/inputunifi/updateweb.go` — carry the field into the web view
- `examples/up.conf.example`, `examples/remote_api_example.{conf,json,yaml}` — documented

## Not a fix for #1030

To be explicit: this does not address the crash reported in #1030, it only lets an affected operator take the endpoint out of the poll cycle. The root cause is still open.

While looking into it I could not find a nil-dereference in that path: `AggregatedDashboard.SpeedTest` is a value struct and `range` over its nil `Data` slice is safe, and `WANProviderCapabilities` is a value type on `WANConfiguration` (the pointer variant on `SpeedTestResult` is nil-checked in the influx and datadog exporters). Worth noting that `promunifi.safeRefresh` already recovers panics in the background refresh path since #1014, which shipped in v3.2.0, while #1030 reproduces on v3.3.0/v3.3.1. That points at either a panic in a goroutine or a non-recoverable runtime fatal rather than something an extra `recover()` in the poll path would catch. `InfluxUnifi.Poll` does not have an equivalent recover, if that path matters to you.

## Testing

- `go build ./...`, `go vet ./pkg/inputunifi/...`, `go test ./pkg/inputunifi/... ./pkg/promunifi/...` all pass
- `golangci-lint run` with v2.9 (same version as CI): 0 issues
- Verified `UP_UNIFI_DEFAULT_SAVE_SPEEDTEST=false` maps onto the field via `cnfg.UnmarshalENV` with a throwaway test (not included in the diff)

Happy to flip the default to false, gate the exporters as well, or rename the key if you'd prefer `save_speed_test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
