### PR TITLE
chore(deps): upgrade unifi to v5.30.0 (fixes #1047)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/prometheus/common v0.70.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
-	github.com/unpoller/unifi/v5 v5.29.0
+	github.com/unpoller/unifi/v5 v5.30.0
 	go.opentelemetry.io/otel v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.44.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.44.0

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/unpoller/unifi/v5 v5.29.0 h1:awO7St93o9PBmw8l1WEzNQcDIreWoxgRENiAgg5VHo0=
-github.com/unpoller/unifi/v5 v5.29.0/go.mod h1:j897mt84iizeLfvXL6KEGlfRdbAua8nTWm5PZjtif30=
+github.com/unpoller/unifi/v5 v5.30.0 h1:M1L/VG4BkZKt+aoqaB/E7foEvDfVFgc5SdPeoyX/qx0=
+github.com/unpoller/unifi/v5 v5.30.0/go.mod h1:j897mt84iizeLfvXL6KEGlfRdbAua8nTWm5PZjtif30=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.opentelemetry.io/auto/sdk v1.2.1 h1:jXsnJ4Lmnqd11kwkBV2LgLoFMZKizbCi5fNZ/ipaZ64=
 go.opentelemetry.io/auto/sdk v1.2.1/go.mod h1:KRTj+aOaElaLi+wW1kO/DZRXwkF4C5xPbEe3ZiIhN7Y=


### PR DESCRIPTION
## Summary

- Bump `github.com/unpoller/unifi/v5` from v5.29.0 to v5.30.0.
- Picks up unpoller/unifi#233, which classifies the new UPS-2U-Pro (`type: usp`) through the existing PDU path.
- Existing PDU exporters then collect its per-outlet voltage, current, power, and power-factor metrics.

## Test plan

- [x] `go mod tidy`
- [x] `go test -timeout=30s ./...`

Closes #1047