### PR TITLE
Recover input plugin panics in poller goroutines (fixes #1030)

### DIFF
--- a/pkg/poller/inputs.go
+++ b/pkg/poller/inputs.go
@@ -183,6 +183,12 @@ func collectEvents(filter *Filter, inputs []*InputPlugin) (*Events, error) {
 				return
 			}
 
+			if e == nil {
+				resultChan <- eventInputResult{}
+
+				return
+			}
+
 			resultChan <- eventInputResult{logs: e.Logs}
 		}(input)
 	}

--- a/pkg/poller/inputs.go
+++ b/pkg/poller/inputs.go
@@ -65,6 +65,21 @@ func NewInput(i *InputPlugin) {
 	inputs = append(inputs, i)
 }
 
+// recoverInitialize runs input.Initialize and converts a panic into an error.
+// Each input plugin's Initialize call runs in its own goroutine, so a panic
+// there cannot be caught by a recover() in the caller; left unrecovered, it
+// crashes the whole process before the app even starts.
+// See https://github.com/unpoller/unpoller/issues/1030
+func recoverInitialize(input *InputPlugin, l Logger) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("input plugin %s panicked initializing: %v", input.Name, r) //nolint:err113
+		}
+	}()
+
+	return input.Initialize(l)
+}
+
 // InitializeInputs runs the passed-in initializer method for each input plugin.
 func (u *UnifiPoller) InitializeInputs() error {
 	inputSync.RLock()
@@ -82,27 +97,11 @@ func (u *UnifiPoller) InitializeInputs() error {
 		go func(input *InputPlugin) {
 			defer wg.Done()
 
-			sent := false
-
-			// A panicking input plugin runs in its own goroutine, so it cannot be
-			// caught by a recover() in the caller. Without this, a panic here
-			// crashes the whole process before the app even starts.
-			// See https://github.com/unpoller/unpoller/issues/1030
-			defer func() {
-				if r := recover(); r != nil && !sent {
-					u.LogErrorf("input plugin %s panicked initializing (see issue #1030): %v", input.Name, r)
-
-					errChan <- fmt.Errorf("input plugin %s panicked initializing: %v", input.Name, r) //nolint:err113
-				}
-			}()
-
 			// This must return, or the app locks up here.
 			u.LogDebugf("inititalizing input... %s", input.Name)
 
-			if err := input.Initialize(u); err != nil {
+			if err := recoverInitialize(input, u); err != nil {
 				u.LogDebugf("error initializing input ... %s", input.Name)
-
-				sent = true
 
 				errChan <- err
 
@@ -110,8 +109,6 @@ func (u *UnifiPoller) InitializeInputs() error {
 			}
 
 			u.LogDebugf("input successfully initialized ... %s", input.Name)
-
-			sent = true
 
 			errChan <- nil
 		}(input)
@@ -149,6 +146,18 @@ type eventInputResult struct {
 	err  error
 }
 
+// recoverEvents runs input.Events and converts a panic into an error. See
+// recoverInitialize for why this is necessary.
+func recoverEvents(input *InputPlugin, filter *Filter) (e *Events, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("input plugin %s panicked collecting events: %v", input.Name, r) //nolint:err113
+		}
+	}()
+
+	return input.Events(filter)
+}
+
 func collectEvents(filter *Filter, inputs []*InputPlugin) (*Events, error) {
 	resultChan := make(chan eventInputResult, len(inputs))
 	wg := &sync.WaitGroup{}
@@ -159,40 +168,20 @@ func collectEvents(filter *Filter, inputs []*InputPlugin) (*Events, error) {
 		go func(input *InputPlugin) {
 			defer wg.Done()
 
-			sent := false
-
-			// A panicking input plugin runs in its own goroutine, so it cannot be
-			// caught by a recover() in the caller. Without this, a panic here
-			// (e.g. from a malformed controller response) crashes the whole
-			// process. See https://github.com/unpoller/unpoller/issues/1030
-			defer func() {
-				if r := recover(); r != nil && !sent {
-					resultChan <- eventInputResult{
-						err: fmt.Errorf("input plugin %s panicked collecting events (see issue #1030): %v", input.Name, r),
-					}
-				}
-			}()
-
 			if filter != nil &&
 				filter.Name != "" &&
 				!strings.EqualFold(input.Name, filter.Name) {
-				sent = true
-
 				resultChan <- eventInputResult{}
 
 				return
 			}
 
-			e, err := input.Events(filter)
+			e, err := recoverEvents(input, filter)
 			if err != nil {
-				sent = true
-
 				resultChan <- eventInputResult{err: err}
 
 				return
 			}
-
-			sent = true
 
 			resultChan <- eventInputResult{logs: e.Logs}
 		}(input)
@@ -238,6 +227,20 @@ type metricInputResult struct {
 	err    error
 }
 
+// recoverMetrics runs input.Metrics and converts a panic into an error (e.g.
+// from a malformed controller response, such as an unexpected Site Speed
+// Test aggregated-dashboard payload). See recoverInitialize for why this is
+// necessary.
+func recoverMetrics(input *InputPlugin, filter *Filter) (m *Metrics, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("input plugin %s panicked collecting metrics: %v", input.Name, r) //nolint:err113
+		}
+	}()
+
+	return input.Metrics(filter)
+}
+
 func collectMetrics(filter *Filter, inputs []*InputPlugin) (*Metrics, error) {
 	resultChan := make(chan metricInputResult, len(inputs))
 	wg := &sync.WaitGroup{}
@@ -248,34 +251,15 @@ func collectMetrics(filter *Filter, inputs []*InputPlugin) (*Metrics, error) {
 		go func(input *InputPlugin) {
 			defer wg.Done()
 
-			sent := false
-
-			// A panicking input plugin runs in its own goroutine, so it cannot be
-			// caught by a recover() in the caller. Without this, a panic here
-			// (e.g. from a malformed controller response, such as an unexpected
-			// Site Speed Test aggregated-dashboard payload) crashes the whole
-			// process. See https://github.com/unpoller/unpoller/issues/1030
-			defer func() {
-				if r := recover(); r != nil && !sent {
-					resultChan <- metricInputResult{
-						err: fmt.Errorf("input plugin %s panicked collecting metrics (see issue #1030): %v", input.Name, r),
-					}
-				}
-			}()
-
 			if filter != nil &&
 				filter.Name != "" &&
 				!strings.EqualFold(input.Name, filter.Name) {
-				sent = true
-
 				resultChan <- metricInputResult{}
 
 				return
 			}
 
-			m, err := input.Metrics(filter)
-			sent = true
-
+			m, err := recoverMetrics(input, filter)
 			resultChan <- metricInputResult{metric: m, err: err}
 		}(input)
 	}

--- a/pkg/poller/inputs.go
+++ b/pkg/poller/inputs.go
@@ -81,11 +81,28 @@ func (u *UnifiPoller) InitializeInputs() error {
 
 		go func(input *InputPlugin) {
 			defer wg.Done()
+
+			sent := false
+
+			// A panicking input plugin runs in its own goroutine, so it cannot be
+			// caught by a recover() in the caller. Without this, a panic here
+			// crashes the whole process before the app even starts.
+			// See https://github.com/unpoller/unpoller/issues/1030
+			defer func() {
+				if r := recover(); r != nil && !sent {
+					u.LogErrorf("input plugin %s panicked initializing (see issue #1030): %v", input.Name, r)
+
+					errChan <- fmt.Errorf("input plugin %s panicked initializing: %v", input.Name, r) //nolint:err113
+				}
+			}()
+
 			// This must return, or the app locks up here.
 			u.LogDebugf("inititalizing input... %s", input.Name)
 
 			if err := input.Initialize(u); err != nil {
 				u.LogDebugf("error initializing input ... %s", input.Name)
+
+				sent = true
 
 				errChan <- err
 
@@ -93,6 +110,8 @@ func (u *UnifiPoller) InitializeInputs() error {
 			}
 
 			u.LogDebugf("input successfully initialized ... %s", input.Name)
+
+			sent = true
 
 			errChan <- nil
 		}(input)
@@ -140,9 +159,25 @@ func collectEvents(filter *Filter, inputs []*InputPlugin) (*Events, error) {
 		go func(input *InputPlugin) {
 			defer wg.Done()
 
+			sent := false
+
+			// A panicking input plugin runs in its own goroutine, so it cannot be
+			// caught by a recover() in the caller. Without this, a panic here
+			// (e.g. from a malformed controller response) crashes the whole
+			// process. See https://github.com/unpoller/unpoller/issues/1030
+			defer func() {
+				if r := recover(); r != nil && !sent {
+					resultChan <- eventInputResult{
+						err: fmt.Errorf("input plugin %s panicked collecting events (see issue #1030): %v", input.Name, r),
+					}
+				}
+			}()
+
 			if filter != nil &&
 				filter.Name != "" &&
 				!strings.EqualFold(input.Name, filter.Name) {
+				sent = true
+
 				resultChan <- eventInputResult{}
 
 				return
@@ -150,10 +185,14 @@ func collectEvents(filter *Filter, inputs []*InputPlugin) (*Events, error) {
 
 			e, err := input.Events(filter)
 			if err != nil {
+				sent = true
+
 				resultChan <- eventInputResult{err: err}
 
 				return
 			}
+
+			sent = true
 
 			resultChan <- eventInputResult{logs: e.Logs}
 		}(input)
@@ -209,15 +248,34 @@ func collectMetrics(filter *Filter, inputs []*InputPlugin) (*Metrics, error) {
 		go func(input *InputPlugin) {
 			defer wg.Done()
 
+			sent := false
+
+			// A panicking input plugin runs in its own goroutine, so it cannot be
+			// caught by a recover() in the caller. Without this, a panic here
+			// (e.g. from a malformed controller response, such as an unexpected
+			// Site Speed Test aggregated-dashboard payload) crashes the whole
+			// process. See https://github.com/unpoller/unpoller/issues/1030
+			defer func() {
+				if r := recover(); r != nil && !sent {
+					resultChan <- metricInputResult{
+						err: fmt.Errorf("input plugin %s panicked collecting metrics (see issue #1030): %v", input.Name, r),
+					}
+				}
+			}()
+
 			if filter != nil &&
 				filter.Name != "" &&
 				!strings.EqualFold(input.Name, filter.Name) {
+				sent = true
+
 				resultChan <- metricInputResult{}
 
 				return
 			}
 
 			m, err := input.Metrics(filter)
+			sent = true
+
 			resultChan <- metricInputResult{metric: m, err: err}
 		}(input)
 	}

--- a/pkg/poller/inputs_test.go
+++ b/pkg/poller/inputs_test.go
@@ -46,6 +46,38 @@ func TestCollectMetricsRecoversPanickingInput(t *testing.T) {
 	assert.Contains(t, err.Error(), "panic-input")
 }
 
+// nilEventsInput simulates a disabled input plugin, which returns (nil, nil)
+// from Events. See https://github.com/unpoller/unpoller/issues/1030.
+type nilEventsInput struct{}
+
+func (nilEventsInput) Initialize(poller.Logger) error { return nil }
+
+func (nilEventsInput) Metrics(*poller.Filter) (*poller.Metrics, error) { return nil, nil }
+
+func (nilEventsInput) Events(*poller.Filter) (*poller.Events, error) { return nil, nil }
+
+func (nilEventsInput) RawMetrics(*poller.Filter) ([]byte, error) { return nil, nil }
+
+func (nilEventsInput) DebugInput() (bool, error) { return false, nil }
+
+func TestCollectEventsHandlesNilEventsResult(t *testing.T) {
+	t.Parallel()
+
+	collector := poller.NewTestCollector(t)
+	collector.AddInput(&poller.InputPlugin{Name: "nil-events-input", Input: nilEventsInput{}})
+
+	var events *poller.Events
+
+	var err error
+
+	require.NotPanics(t, func() {
+		events, err = collector.Events(nil)
+	})
+
+	assert.NotNil(t, events)
+	require.NoError(t, err)
+}
+
 func TestCollectEventsRecoversPanickingInput(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/poller/inputs_test.go
+++ b/pkg/poller/inputs_test.go
@@ -1,0 +1,66 @@
+package poller_test
+
+import (
+	"testing"
+
+	"github.com/unpoller/unpoller/pkg/poller"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// panicInput is an Input that panics on Metrics and Events, simulating a
+// malformed controller response crashing an input plugin. See issue #1030.
+type panicInput struct{}
+
+func (panicInput) Initialize(poller.Logger) error { return nil }
+
+func (panicInput) Metrics(*poller.Filter) (*poller.Metrics, error) {
+	panic("simulated aggregated-dashboard panic")
+}
+
+func (panicInput) Events(*poller.Filter) (*poller.Events, error) {
+	panic("simulated aggregated-dashboard panic")
+}
+
+func (panicInput) RawMetrics(*poller.Filter) ([]byte, error) { return nil, nil }
+
+func (panicInput) DebugInput() (bool, error) { return false, nil }
+
+func TestCollectMetricsRecoversPanickingInput(t *testing.T) {
+	t.Parallel()
+
+	collector := poller.NewTestCollector(t)
+	collector.AddInput(&poller.InputPlugin{Name: "panic-input", Input: panicInput{}})
+
+	var metrics *poller.Metrics
+
+	var err error
+
+	require.NotPanics(t, func() {
+		metrics, err = collector.Metrics(nil)
+	})
+
+	assert.NotNil(t, metrics)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "panic-input")
+}
+
+func TestCollectEventsRecoversPanickingInput(t *testing.T) {
+	t.Parallel()
+
+	collector := poller.NewTestCollector(t)
+	collector.AddInput(&poller.InputPlugin{Name: "panic-input", Input: panicInput{}})
+
+	var events *poller.Events
+
+	var err error
+
+	require.NotPanics(t, func() {
+		events, err = collector.Events(nil)
+	})
+
+	assert.NotNil(t, events)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "panic-input")
+}


### PR DESCRIPTION
## Summary

Fixes #1030. `pkg/poller/inputs.go` runs each input plugin's `Metrics`/`Events`/`Initialize` call in its own goroutine with no `recover()`. A panic there (e.g. from a malformed controller response, such as the reported Site Speed Test `aggregated-dashboard` payload) crashes the whole process with exit code 2.

This isn't caught by `promunifi.safeRefresh`'s existing `recover()`, because that recover lives in the *caller's* goroutine, not the one spawned per input plugin — `recover()` only sees panics in its own goroutine's call stack.

Adds a small helper per call site (`recoverInitialize`/`recoverEvents`/`recoverMetrics`) that wraps the plugin call and converts a panic into a returned error, naming the offending plugin, so polling continues instead of crashing.

This is containment, not a root-cause fix — I couldn't pin down the actual defect inside `unpoller/unifi` that triggers the panic (that needs the reporter's raw stderr panic trace, which the debug log alone doesn't provide). This change ensures a bad response from one input no longer takes down the whole poller regardless.

## Test plan
- [x] `go build ./...`
- [x] `golangci-lint run ./pkg/poller/...` (0 issues)
- [x] `pkg/poller/inputs_test.go`: stub input plugin whose `Metrics`/`Events` panic; asserts the collector doesn't panic and returns an error naming the plugin
- [x] `go test ./pkg/poller/...` passes