### PR TITLE
promunifi: add state label to wan_interface_state metric

### DIFF
--- a/pkg/promunifi/wan_status.go
+++ b/pkg/promunifi/wan_status.go
@@ -10,11 +10,13 @@ type wanStatus struct {
 }
 
 func descWANStatus(ns string) *wanStatus {
-	labels := []string{"site_name", "wan_interface", "wan_networkgroup"}
+	labels := []string{"site_name", "wan_interface", "wan_networkgroup", "state"}
 
 	return &wanStatus{
 		InterfaceState: prometheus.NewDesc(ns+"wan_interface_state",
-			"WAN interface state: 1=ACTIVE, 0=other",
+			"WAN interface state: 1=ACTIVE, 0=other. The state label carries the raw "+
+				"controller value (ACTIVE, BACKUP, or DISCONNECTED) so BACKUP and DISCONNECTED "+
+				"can be distinguished.",
 			labels, nil),
 	}
 }
@@ -33,7 +35,7 @@ func (u *promUnifi) exportWANStatus(r report, ws *unifi.WANStatus) {
 	}
 
 	for _, iface := range ws.WANInterfaces {
-		labels := []string{ws.SiteName, iface.Name, iface.WANNetworkgroup}
+		labels := []string{ws.SiteName, iface.Name, iface.WANNetworkgroup, iface.State}
 
 		r.send([]*metric{
 			{u.WANStatus.InterfaceState, gauge, wanStateValue(iface.State), labels},


### PR DESCRIPTION
Fixes #1045.

The `unpoller_wan_interface_state` metric (added in v3.0.0) already reports WAN up/down as a 1/0 gauge, but BACKUP and DISCONNECTED interfaces both show as `0`, making a healthy standby WAN indistinguishable from an actually offline one. InfluxDB and DataDog already expose the raw controller state; this adds a `state` label to the Prometheus metric so it does too.

No breaking changes — the gauge's 1/0 semantics are unchanged, just a label added.