### PR TITLE
inputunifi: skip alarms endpoint on 400 api.err.InvalidObject

### DIFF
--- a/pkg/inputunifi/collectevents.go
+++ b/pkg/inputunifi/collectevents.go
@@ -135,6 +135,16 @@ func (u *InputUnifi) collectAlarms(logs []any, sites []*unifi.Site, c *Controlle
 				return logs, nil
 			}
 
+			if isAlarmsInvalidObject(err) {
+				// Some Network 10.x+ controllers (see unpoller/unpoller#1050) return
+				// HTTP 400 api.err.InvalidObject for list/alarm instead of a 404 when
+				// the endpoint is gone. unifi.ErrInvalidStatusCode doesn't carry a
+				// parsed status code, so we match on the formatted resp.Status text.
+				u.Logf("[%s] Alarms endpoint returned 400 (likely removed on this controller version): %v", c.URL, err)
+
+				return logs, nil
+			}
+
 			if err != nil {
 				return logs, fmt.Errorf("unifi.GetAlarms(): %w", err)
 			}
@@ -156,6 +166,12 @@ func (u *InputUnifi) collectAlarms(logs []any, sites []*unifi.Site, c *Controlle
 	}
 
 	return logs, nil
+}
+
+// isAlarmsInvalidObject reports whether err is a 400 api.err.InvalidObject response,
+// which some Network 10.x+ controllers return from list/alarm in place of a 404.
+func isAlarmsInvalidObject(err error) bool {
+	return errors.Is(err, unifi.ErrInvalidStatusCode) && strings.Contains(err.Error(), ": 400 ")
 }
 
 func (u *InputUnifi) collectAnomalies(logs []any, sites []*unifi.Site, c *Controller) ([]any, error) {


### PR DESCRIPTION
## Summary

Fixes #1050. On some Network 10.x+ controllers (UniFi OS, Network 10.5.67 confirmed), `list/alarm` returns HTTP 400 with `meta.msg == "api.err.InvalidObject"` instead of a 404 when the endpoint is gone. `collectAlarms` only skipped on `unifi.ErrEndpointNotFound`, so this 400 fell through as a real error and logged on every poll interval forever.

`collectAlarms` now also skips (with a visible log line, like `collectIDs` does for its 404 case) when `GetAlarmsSite` returns `unifi.ErrInvalidStatusCode` for a 400 response specifically — not for other statuses like 401/403/500, which should still surface as real errors.

Since `unifi.ErrInvalidStatusCode` doesn't carry a parsed status code (v5.30.0 formats it into the error message via `resp.Status`), the check matches on the formatted `": 400 "` substring. A cleaner fix would be for the `unifi` client to expose the status code or `meta.msg` on the error directly — noted as a follow-up, but out of scope for this repo.

Scoped to `collectAlarms` only; the reporter confirmed `stat/anomalies` still works fine on their controller, so `collectAnomalies`/`collectIDs`/`collectEvents` are untouched.

## Test plan

- [x] `go build ./...`
- [x] `gofmt -l` / `go vet` clean on the changed file
- [ ] Reporter to confirm against their Network 10.5.67 controller (offered to test in the issue)