### PR TITLE
fix: InfluxDB and Datadog reported tx packets under stat_rx_packets

### DIFF
--- a/pkg/datadogunifi/usw.go
+++ b/pkg/datadogunifi/usw.go
@@ -67,7 +67,7 @@ func (u *DatadogUnifi) batchUSWstat(sw *unifi.Sw) map[string]float64 {
 		"stat_rx_dropped": sw.RxDropped.Val,
 		"stat_rx_errors":  sw.RxErrors.Val,
 		"stat_rx_frags":   sw.RxFrags.Val,
-		"stat_rx_packets": sw.TxPackets.Val,
+		"stat_rx_packets": sw.RxPackets.Val,
 		"stat_tx_bytes":   sw.TxBytes.Val,
 		"stat_tx_dropped": sw.TxDropped.Val,
 		"stat_tx_errors":  sw.TxErrors.Val,

--- a/pkg/influxunifi/pdu.go
+++ b/pkg/influxunifi/pdu.go
@@ -110,7 +110,7 @@ func (u *InfluxUnifi) batchPDUstat(sw *unifi.Sw) map[string]any {
 		"stat_rx_dropped": sw.RxDropped.Val,
 		"stat_rx_errors":  sw.RxErrors.Val,
 		"stat_rx_frags":   sw.RxFrags.Val,
-		"stat_rx_packets": sw.TxPackets.Val,
+		"stat_rx_packets": sw.RxPackets.Val,
 		"stat_tx_bytes":   sw.TxBytes.Val,
 		"stat_tx_dropped": sw.TxDropped.Val,
 		"stat_tx_errors":  sw.TxErrors.Val,

--- a/pkg/influxunifi/usw.go
+++ b/pkg/influxunifi/usw.go
@@ -63,7 +63,7 @@ func (u *InfluxUnifi) batchUSWstat(sw *unifi.Sw) map[string]any {
 		"stat_rx_dropped": sw.RxDropped.Val,
 		"stat_rx_errors":  sw.RxErrors.Val,
 		"stat_rx_frags":   sw.RxFrags.Val,
-		"stat_rx_packets": sw.TxPackets.Val,
+		"stat_rx_packets": sw.RxPackets.Val,
 		"stat_tx_bytes":   sw.TxBytes.Val,
 		"stat_tx_dropped": sw.TxDropped.Val,
 		"stat_tx_errors":  sw.TxErrors.Val,


### PR DESCRIPTION
Both the InfluxDB and Datadog switch stat blocks put `sw.TxPackets` into `stat_rx_packets`, so the transmit count goes out under both names and `sw.RxPackets` never gets writen at all. Influxs PDU block has the same line. The helper is shared, so it's UDM, UDB, UCI and UXG as well, not just switches, and anyone already graphing `stat_rx_packets` will see the number change once this ships.

`promunifi` reads `sw.RxPackets` off the same struct for `switch_receive_packets_total`, which is where I got the direction from. No controller here to point at though, so none of this has been near live data.
