### PR TITLE
ci: bump golangci-lint to v2.13 for Go 1.27 deps

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,6 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          # v2.9 is built with Go 1.26 so it can type-check deps (e.g. golang.org/x/crypto, x/net) that include go1.26-only files.
-          version: v2.9
+          # v2.13 is built with Go 1.27 so it can type-check deps that include go1.27-only files.
+          version: v2.13
           skip-cache: true


### PR DESCRIPTION
## Summary
- Bump golangci-lint from v2.9 to v2.13 in the Build workflow
- v2.9 is built with Go 1.26 and panics when type-checking dependencies with go1.27-only source files

## Test plan
- [ ] CI lint job passes on this PR

Made with [Cursor](https://cursor.com)