### PR TITLE
fix: use go install for release build tool dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ $(BINARY).1.gz: md2roff
 
 md2roff: $(shell go env GOPATH)/bin/md2roff
 $(shell go env GOPATH)/bin/md2roff:
-	cd /tmp ; go get $(MD2ROFF_BIN) ; go install $(MD2ROFF_BIN)
+	go install $(MD2ROFF_BIN)
 
 # TODO: provide a template that adds the date to the built html file.
 readme: README.html
@@ -55,7 +55,7 @@ rsrc: rsrc.syso
 rsrc.syso: init/windows/application.ico init/windows/manifest.xml $(shell go env GOPATH)/bin/rsrc
 	$(shell go env GOPATH)/bin/rsrc -ico init/windows/application.ico -manifest init/windows/manifest.xml
 $(shell go env GOPATH)/bin/rsrc:
-	cd /tmp ; go get $(RSRC_BIN) ; go install $(RSRC_BIN)@latest
+	go install $(RSRC_BIN)@latest
 
 build-and-release: export DOCKER_REGISTRY = ghcr.io
 build-and-release: export DOCKER_IMAGE_NAME = unpoller/unpoller


### PR DESCRIPTION
## Summary
- Fixes the v5.0.0 release pipeline failure in the GoReleaser `make man` hook
- Replaces deprecated `go get` with `go install` for `md2roff` and `rsrc` build tools

## Context
The release job failed with:
```
go: go.mod file not found in current directory or any parent directory.
	'go get' is no longer supported outside a module.
make: *** [Makefile:46: /home/runner/go/bin/md2roff] Error 1
```

Modern Go toolchains require `go install pkg@version` instead of `cd /tmp && go get ... && go install ...`.

## Test plan
- [x] Verified locally: `make man` succeeds after removing md2roff and rebuilding
- [ ] Merge to master
- [ ] Re-run the Release workflow (either re-dispatch for v5.0.0 after tagging, or cut v5.0.1)


Made with [Cursor](https://cursor.com)