### PR TITLE
fix: respect configured default_site_name_override in remote mode

### DIFF
--- a/pkg/inputunifi/remote.go
+++ b/pkg/inputunifi/remote.go
@@ -188,14 +188,17 @@ func (u *InputUnifi) discoverRemoteControllers(apiKey string) ([]*Controller, er
 		// (consoleName was already set above in the loop)
 
 		// If we only have one site and it's "default" (case-insensitive), use the console name as override
+		// unless the user already configured default_site_name_override in up.conf.
 		// Note: We keep the actual site name ("default") for API calls, but set the override
 		// for display/metric naming purposes.
 		if len(siteNames) == 1 && strings.EqualFold(siteNames[0], "default") && consoleName != "" {
-			controller.DefaultSiteNameOverride = consoleName
+			if controller.DefaultSiteNameOverride == "" {
+				controller.DefaultSiteNameOverride = consoleName
+				u.LogDebugf("Using console name '%s' as default site name override for Cloud Gateway (API will use 'default')", consoleName)
+			}
+
 			// Keep the actual site name for API calls
 			controller.Sites = siteNames
-
-			u.LogDebugf("Using console name '%s' as default site name override for Cloud Gateway (API will use 'default')", consoleName)
 		} else if len(siteNames) > 0 {
 			controller.Sites = siteNames
 		} else {


### PR DESCRIPTION
## Summary

- Fixes #1057
- Remote API discovery no longer overwrites a user-configured `default_site_name_override` with the console name
- The console name fallback still applies when no override is configured (preserving existing Cloud Gateway behavior)

## Problem

When using UniFi remote API mode with a Cloud Gateway that has a single `default` site, UniFi Poller automatically sets `default_site_name_override` to the console name (e.g. "Cloud Gateway Max"). This happened unconditionally, overwriting any value the user set in `up.conf`.

## Fix

In `discoverRemoteControllers`, only set the console name as the default site name override when `controller.DefaultSiteNameOverride` is empty after defaults are applied from config.

## Test plan

- [x] Configure `default_site_name_override` in `up.conf` with remote API mode enabled
- [x] Verify debug logs no longer show "Using console name ... as default site name override"
- [x] Verify metrics use the configured override name instead of the console name
- [x] Verify Cloud Gateways without a configured override still get the console name fallback


Made with [Cursor](https://cursor.com)