### PR TITLE
chore(deps): bump github.com/unpoller/unifi/v6 to v6.0.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/common v0.70.1
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.12.1
-	github.com/unpoller/unifi/v6 v6.0.0
+	github.com/unpoller/unifi/v6 v6.0.2
 	go.opentelemetry.io/otel v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.45.0
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.45.0

--- a/go.sum
+++ b/go.sum
@@ -119,8 +119,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.12.1 h1:EuwCh5fleGS7H32xRwO3wRGT7DxrDhLAT6FF8MpWDWE=
 github.com/stretchr/testify v1.12.1/go.mod h1:MDEgiDPPsNp5cuIrHPPCyornHKgEVbtFUmoNlxoYthg=
-github.com/unpoller/unifi/v6 v6.0.0 h1:NVlAWgHpW1HsS9gRgu/RVHasPfoyrzAl/TB18qMu6wc=
-github.com/unpoller/unifi/v6 v6.0.0/go.mod h1:ad72+qBh3C4avgn2ZCwfMJlLuEKOMqQzKE9RvzE0Nfg=
+github.com/unpoller/unifi/v6 v6.0.2 h1:Mzcn0zSTnFxMZuFIoVqhSkECT1sX9S7RJ8e/ZxikOcw=
+github.com/unpoller/unifi/v6 v6.0.2/go.mod h1:d7dz1cBxVbbFZobNRcdUHHYtTdicVyZ05J5OmgoINa8=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/zeebo/assert v1.3.0 h1:g7C04CbJuIDKNPFHmsk4hwZDO5O+kntRxzaUoNXj+IQ=
 github.com/zeebo/assert v1.3.0/go.mod h1:Pq9JiuJQpG8JLJdtkwrJESF0Foym2/D9XMU5ciN/wJ0=


### PR DESCRIPTION
Bumps `github.com/unpoller/unifi/v6` from `v6.0.0` to `v6.0.2`.

Picks up, among others:

- **unpoller/unifi#241** — `fix(wan): read WAN status from the v2 endpoint on UniFi OS`. On UniFi OS consoles (`u.new == true`), `GetWANStatus` was hitting `/api/s/{site}/stat/status`, which does not serve WAN status there; the same payload is available at `/wan/load-balancing/status` (the `APIWANLoadBalancingStatusPath` constant already existed). Without this, `unpoller_device_wan_*` series are simply absent on UDM/UDR/UX gateways.
- **unpoller/unifi#240 / #242** — `NewProtectClient` for Protect-only consoles (UNVR), which #1068 builds on.

`go.mod`/`go.sum` only — no transitive version changes: every dependency of `unifi/v6 v6.0.2` (`testify v1.12.1`, `go.yaml.in/yaml/v3 v3.0.5`, `gofakeit v6.28.0`, `golang.org/x/net v0.58.0`) is already required at that exact version here. The diff between `v6.0.0` and `v6.0.2` is purely additive on the public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)