### PR TITLE
feat(wan): label WAN interface state with its source

### DIFF
--- a/pkg/promunifi/wan_status.go
+++ b/pkg/promunifi/wan_status.go
@@ -10,7 +10,7 @@ type wanStatus struct {
 }
 
 func descWANStatus(ns string) *wanStatus {
-	labels := []string{"site_name", "wan_interface", "wan_networkgroup", "state"}
+	labels := []string{"site_name", "source", "wan_interface", "wan_networkgroup", "state"}
 
 	return &wanStatus{
 		InterfaceState: prometheus.NewDesc(ns+"wan_interface_state",
@@ -35,7 +35,7 @@ func (u *promUnifi) exportWANStatus(r report, ws *unifi.WANStatus) {
 	}
 
 	for _, iface := range ws.WANInterfaces {
-		labels := []string{ws.SiteName, iface.Name, iface.WANNetworkgroup, iface.State}
+		labels := []string{ws.SiteName, ws.SourceName, iface.Name, iface.WANNetworkgroup, iface.State}
 
 		r.send([]*metric{
 			{u.WANStatus.InterfaceState, gauge, wanStateValue(iface.State), labels},

--- a/pkg/promunifi/wan_status_test.go
+++ b/pkg/promunifi/wan_status_test.go
@@ -1,0 +1,55 @@
+//nolint:testpackage // white-box: exercises the unexported descriptors and export path.
+package promunifi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unifi/v6"
+)
+
+// TestExportWANStatusIsAttributed is the point of this change. Every UniFi OS
+// console names its only site "default", so site_name alone cannot tell two
+// controllers apart: an instance polling several of them emitted WAN status
+// that was indistinguishable, and any downstream attribution had to be guessed.
+func TestExportWANStatusIsAttributed(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeReport{}
+	u := &promUnifi{WANStatus: descWANStatus("unifi_")}
+	u.exportWANStatus(r, &unifi.WANStatus{
+		SiteName:   "Default (default)",
+		SourceName: "https://udr.example",
+		WANInterfaces: []unifi.WANStatusInterface{
+			{Name: "Internet 1", State: "ACTIVE", WANNetworkgroup: "WAN"},
+			{Name: "Cellular", State: "BACKUP", WANNetworkgroup: "WAN3"},
+		},
+	})
+
+	require.Len(t, r.sent, 2, "one metric per WAN interface")
+
+	a := assert.New(t)
+
+	for _, m := range r.sent {
+		require.Len(t, m.Labels, 5)
+		a.Equal("Default (default)", m.Labels[0], "site_name")
+		a.Equal("https://udr.example", m.Labels[1], "source must identify the controller")
+	}
+
+	a.Equal(float64(1), r.sent[0].Value, "ACTIVE is 1")
+	a.Equal(float64(0), r.sent[1].Value, "anything else is 0")
+	a.Equal("BACKUP", r.sent[1].Labels[4], "the raw state is kept as a label")
+}
+
+// TestExportWANStatusNilIsSafe pins the existing guard: a site with no gateway
+// yields a nil status, and that must not panic a poll.
+func TestExportWANStatusNilIsSafe(t *testing.T) {
+	t.Parallel()
+
+	r := &fakeReport{}
+	u := &promUnifi{WANStatus: descWANStatus("unifi_")}
+	u.exportWANStatus(r, nil)
+
+	assert.Empty(t, r.sent)
+}


### PR DESCRIPTION
### The problem

`unpoller_wan_interface_state` ships with `site_name` and nothing else to identify where it came from:

```go
labels := []string{"site_name", "wan_interface", "wan_networkgroup", "state"}
```

That is not enough, because **every UniFi OS console names its only site `default`** and it cannot be renamed in the UI. `site_name` is `"Default (default)"` on all of them. An instance polling several controllers emits WAN status that is **indistinguishable**, and downstream attribution has to be guessed.

### Observed in production

Before the fix, a scrape config guessing from `site_name` filed a UDM's WAN state under the wrong customer. No error, no missing series — just wrong data under someone else's name, which is the failure mode nobody notices.

The contrast makes the point: `unpoller_device_info`, from the same controller and the same site, is attributed correctly — because it carries `source`.

### The fix

`unifi/v6.1.0` (#244) added `SourceName` to `WANStatus`, stamped from the controller URL in all three read paths. `go.mod` is already on v6.1.0, so this only has to read the field: one label added to the descriptor, one value added to the slice.

Same shape as #1071, which did this for `unpoller_wan_*`.

### Tests

`pkg/promunifi/wan_status_test.go`, using the `fakeReport` already present in the package:

- **`TestExportWANStatusIsAttributed`** — every emitted metric carries both `site_name` and `source`; the raw state is kept as a label and maps to 1 only for `ACTIVE`. **Fails on master, passes here.**
- **`TestExportWANStatusNilIsSafe`** — a site with no gateway yields a nil status, which must not panic a poll.

`go build`, `go vet` and the full suite pass.
