### PR TITLE
fix(inputunifi): apply default_site_name_override to log entries

### DIFF
--- a/pkg/inputunifi/collectevents.go
+++ b/pkg/inputunifi/collectevents.go
@@ -71,6 +71,21 @@ func (u *InputUnifi) collectControllerEvents(c *Controller) ([]any, error) {
 	return logs, nil
 }
 
+// overrideSiteName applies the controller's default_site_name_override to a
+// site name that is still the controller's stock default.
+//
+// Log entries need this applied here, one collector at a time. Metrics get the
+// override from augmentMetrics, but log entries never pass through it: they
+// leave by collectControllerEvents, which reads its sites straight from
+// getFilteredSites. So whatever a collector appends is what ships.
+func overrideSiteName(c *Controller, siteName string) string {
+	if c.DefaultSiteNameOverride != "" && isDefaultSiteName(siteName) {
+		return c.DefaultSiteNameOverride
+	}
+
+	return siteName
+}
+
 func (u *InputUnifi) collectAlarms(logs []any, sites []*unifi.Site, c *Controller) ([]any, error) {
 	if *c.SaveAlarms {
 		u.LogDebugf("Collecting controller alarms: %s (%s)", c.URL, c.ID)
@@ -161,6 +176,7 @@ func (u *InputUnifi) collectAlarms(logs []any, sites []*unifi.Site, c *Controlle
 			for _, e := range events {
 				// Try to extract MAC address from alarm message and enrich with device name
 				e.DeviceName = u.extractDeviceNameFromAlarm(e, macToName)
+				e.SiteName = overrideSiteName(c, e.SiteName)
 
 				logs = append(logs, e)
 
@@ -202,9 +218,7 @@ func (u *InputUnifi) collectAnomalies(logs []any, sites []*unifi.Site, c *Contro
 			}
 
 			for _, e := range events {
-				if c.DefaultSiteNameOverride != "" && isDefaultSiteName(e.SiteName) {
-					e.SiteName = c.DefaultSiteNameOverride
-				}
+				e.SiteName = overrideSiteName(c, e.SiteName)
 
 				logs = append(logs, e)
 
@@ -241,6 +255,8 @@ func (u *InputUnifi) collectEvents(logs []any, sites []*unifi.Site, c *Controlle
 
 			for _, e := range events {
 				e := redactEvent(e, c.HashPII, c.DropPII)
+				e.SiteName = overrideSiteName(c, e.SiteName)
+
 				logs = append(logs, e)
 
 				webserver.NewInputEvent(PluginName, s.ID+"_events", &webserver.Event{
@@ -270,6 +286,8 @@ func (u *InputUnifi) collectSyslog(logs []any, sites []*unifi.Site, c *Controlle
 
 		for _, e := range entries {
 			e := redactSystemLogEntry(e, c.HashPII, c.DropPII)
+			e.SiteName = overrideSiteName(c, e.SiteName)
+
 			logs = append(logs, e)
 
 			webserver.NewInputEvent(PluginName, e.SiteName+"_syslog", &webserver.Event{
@@ -362,6 +380,8 @@ func (u *InputUnifi) collectIDs(logs []any, sites []*unifi.Site, c *Controller) 
 			}
 
 			for _, e := range events {
+				e.SiteName = overrideSiteName(c, e.SiteName)
+
 				logs = append(logs, e)
 
 				webserver.NewInputEvent(PluginName, s.ID+"_ids", &webserver.Event{

--- a/pkg/inputunifi/collectevents_test.go
+++ b/pkg/inputunifi/collectevents_test.go
@@ -1,0 +1,54 @@
+package inputunifi // nolint: testpackage
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestOverrideSiteName is what this change exists for. Every UniFi OS console
+// calls its only site "default", so a poller watching several of them ships log
+// entries that cannot be told apart — which is what default_site_name_override
+// is meant to solve, and did not, on this path.
+func TestOverrideSiteName(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		override string
+		siteName string
+		want     string
+	}{
+		"stock name from a UniFi OS console": {
+			override: "Les_Solidarites",
+			siteName: "Default (default)",
+			want:     "Les_Solidarites",
+		},
+		"bare default": {
+			override: "Les_Solidarites",
+			siteName: "default",
+			want:     "Les_Solidarites",
+		},
+		"a site the operator already named is left alone": {
+			override: "Les_Solidarites",
+			siteName: "CharlHot - SweetHome",
+			want:     "CharlHot - SweetHome",
+		},
+		"no override configured is a no-op": {
+			override: "",
+			siteName: "Default (default)",
+			want:     "Default (default)",
+		},
+		"empty site name is not a default": {
+			override: "Les_Solidarites",
+			siteName: "",
+			want:     "",
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			c := &Controller{DefaultSiteNameOverride: tc.override}
+			assert.Equal(t, tc.want, overrideSiteName(c, tc.siteName))
+		})
+	}
+}


### PR DESCRIPTION
## The problem

`default_site_name_override` is applied in `augmentMetrics`, which only the metrics path goes through. Log entries leave by `collectControllerEvents`, which reads its sites straight from `getFilteredSites` — where the override is [deliberately not applied](https://github.com/unpoller/unpoller/blob/master/pkg/inputunifi/collector.go#L1434) — so events, alarms, IDS records and system-log entries ship with the controller's stock site name.

Four of the five site-scoped log collectors are affected. `collectAnomalies` already did this inline, which is what makes the omission visible:

| collector | override applied before this PR |
|---|---|
| `collectAnomalies` | yes (inline) |
| `collectAlarms` | no |
| `collectEvents` | no |
| `collectSyslog` | no |
| `collectIDs` | no |

## Why it matters

The consequence is worst for a poller watching several UniFi OS consoles, which is the case the option exists for: each console calls its only site `default`, so their log entries are indistinguishable downstream. In Loki, every stream from those consoles lands under `site_name="Default (default)"` regardless of which console produced it, and no relabeling downstream can separate them again — the information is gone by the time it leaves the poller.

The metrics from those same consoles are correctly named, so the two outputs disagree about what the same site is called.

Observed here on a poller watching several UDR/UDM consoles: `unpoller_device_*` metrics carry the configured names while the Loki streams carry `Default (default)`.

## The change

Extract the check `collectAnomalies` was already doing into `overrideSiteName`, and call it from all five collectors so the two paths agree. Setting `SiteName` before the `webserver.NewInputEvent` call means the web UI's event tags get the corrected name too.

## On safety

Only `Site.Name` ever reaches an API path — `Site.SiteName` is a display name throughout the library, used for struct fields and error messages. Overriding it here cannot affect any request. That is what `applySiteNameOverride`'s own doc comment says: *"keeping `default` for API calls"*.

The comment in `getFilteredSites` — *"We do NOT override the site name here because it's used in API calls"* — appears to conflate the two fields. I have not touched it, since fixing the collectors is the smaller change; happy to follow up if you would rather the override moved there once and for all.

## Testing

`go test ./pkg/inputunifi/` — a table test on `overrideSiteName` covering the stock UniFi OS name, the bare `default`, an operator-named site (left alone), no override configured, and the empty name. This adds the first test file to the package.

Verified against live controllers: with the fix, system-log entries reach Loki under the configured site name instead of `Default (default)`.