### PR TITLE
fix(promunifi): default an unset http_listen instead of failing validation

### DIFF
--- a/pkg/promunifi/collector.go
+++ b/pkg/promunifi/collector.go
@@ -234,7 +234,7 @@ func (u *promUnifi) DebugOutput() (bool, error) {
 	}
 
 	if u.HTTPListen == "" {
-		return false, fmt.Errorf("invalid listen string")
+		u.HTTPListen = defaultHTTPListen
 	}
 
 	// check the port

--- a/pkg/promunifi/collector_test.go
+++ b/pkg/promunifi/collector_test.go
@@ -1,0 +1,22 @@
+//nolint:testpackage // white-box: exercises the unexported output plugin.
+package promunifi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/unpoller/unpoller/pkg/poller"
+)
+
+func TestDebugOutputAcceptsUnsetHTTPListen(t *testing.T) {
+	poller.SetHealthCheckMode(true)
+	t.Cleanup(func() { poller.SetHealthCheckMode(false) })
+
+	u := &promUnifi{Config: &Config{}}
+
+	ok, err := u.DebugOutput()
+	require.NoError(t, err)
+	assert.True(t, ok)
+	assert.Equal(t, defaultHTTPListen, u.HTTPListen)
+}


### PR DESCRIPTION
`otelunifi`, `influxunifi` and `datadogunifi` all call `setConfigDefaults()` at the top of `DebugOutput()`, straight after the same two guards. promunifi hasnt got one, so it validates the config as written rather than the one `Run()` is about to build, and an unset `http_listen` doesnt survive that:

```
$ printf '[prometheus]\n' > c.conf
$ unpoller --config c.conf --health
[ERROR] health check failed: output prometheus validation failed: invalid listen string
```

Exit 1. Run that same binary on that same config without `--health` and it logs `Prometheus exported at http://0.0.0.0:9130/` and answers 200 on `/metrics`, because fifty-odd lines under the check, `Run()` fills the empty address in itself. The `HEALTHCHECK` in the Dockerfile is `--health` every 30s with 3 retries, so that's a container going unhealthy about two minutes in with a working poller sat inside it.

One line of this is the fix. The other twenty-two are a new `collector_test.go`. Nobody hits it on the stock image, since the `up.conf.example` baked in there does set `http_listen`; you get here by mounting a config of your own.
